### PR TITLE
PitchShiftTimeStretch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tests/local/*
 .coverage
 build/*
 dist/*
+docs/_build/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 scaper.egg-info/*
 tests/local/*
 .coverage
+build/*
+dist/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ python:
     - "3.4"
     - "3.5"
 
+addons:
+  apt:
+    packages:
+    - sox
+    - ffmpeg
+
 before_install:
     - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
           wget http://repo.continuum.io/miniconda/Miniconda-3.8.3-Linux-x86_64.sh -O miniconda.sh;

--- a/scaper/audio.py
+++ b/scaper/audio.py
@@ -1,0 +1,104 @@
+# CREATED: 4/23/17 15:37 by Justin Salamon <justin.salamon@nyu.edu>
+
+'''
+Utility functions for audio processing using FFMPEG (beyond sox). Based on:
+https://github.com/mathos/neg23/
+'''
+
+import subprocess
+from .scaper_exceptions import ScaperError
+
+
+def r128stats(filepath):
+    """ takes a path to an audio file, returns a dict with the loudness
+    stats computed by the ffmpeg ebur128 filter """
+    ffargs = ['ffmpeg',
+              '-nostats',
+              '-i',
+              filepath,
+              '-filter_complex',
+              'ebur128',
+              '-f',
+              'null',
+              '-']
+    try:
+        proc = subprocess.Popen(ffargs, stderr=subprocess.PIPE,
+                                universal_newlines=True)
+        stats = proc.communicate()[1]
+        summary_index = stats.rfind('Summary:')
+        summary_list = stats[summary_index:].split()
+        i_lufs = float(summary_list[summary_list.index('I:') + 1])
+        i_thresh = float(summary_list[summary_list.index('I:') + 4])
+        lra = float(summary_list[summary_list.index('LRA:') + 1])
+        lra_thresh = float(summary_list[summary_list.index('LRA:') + 4])
+        lra_low = float(summary_list[summary_list.index('low:') + 1])
+        lra_high = float(summary_list[summary_list.index('high:') + 1])
+        stats_dict = {'I': i_lufs, 'I Threshold': i_thresh, 'LRA': lra,
+                      'LRA Threshold': lra_thresh, 'LRA Low': lra_low,
+                      'LRA High': lra_high}
+    except:
+        return False
+    return stats_dict
+
+
+def get_integrated_lufs(filepath):
+    '''Returns the integrated lufs for an audiofile'''
+
+    loudness_stats = r128stats(filepath)
+    if not loudness_stats:
+        raise ScaperError(
+            'Unable to obtain LUFS state for {:s}'.format(filepath))
+    return loudness_stats['I']
+
+
+def linear_gain(i_lufs, goal_lufs=-23):
+    """ takes a floating point value for i_lufs, returns the necessary
+    multiplier for audio gain to get to the goal_lufs value """
+    gain_log = -(i_lufs - goal_lufs)
+    return 10 ** (gain_log / 20.0)
+
+
+def ff_apply_gain(inpath, outpath, linear_amount):
+    """ creates a file from inpath at outpath, applying a filter
+    for audio volume, multiplying by linearAmount """
+    ffargs = ['ffmpeg', '-y', '-f', 'wav', '-i', inpath,
+              '-af', 'volume=' + str(linear_amount),
+              '-f', 'wav']
+    if outpath[-4:].lower() == '.mp3':
+        ffargs += ['-acodec', 'libmp3lame', '-aq', '0']
+    ffargs += [outpath]
+    try:
+        subprocess.Popen(ffargs, stderr=subprocess.PIPE)
+    except:
+        return False
+    return True
+
+
+def normalize_audio_lufs(infile, outfile, goal_lufs=-23):
+    '''
+    Take infile, normalize to goal_lufs, and save to outfile.
+    Parameters
+    ----------
+    infile : str
+        Path to input audio file
+    outfile : str
+        Path to output audio file
+    goal_lufs : float
+        Desired LUFS level after normalization
+
+    Returns
+    -------
+
+    '''
+
+    loudness_stats = r128stats(infile)
+    if not loudness_stats:
+        raise ScaperError(
+            'Unable to obtain LUFS state for {:s}'.format(infile))
+
+    gain_amount = linear_gain(loudness_stats['I'], goal_lufs=goal_lufs)
+    ff_gain_success = ff_apply_gain(infile, outfile, gain_amount)
+    if not ff_gain_success:
+        raise ScaperError(
+            'Unable to apply gain of {:.2f} (goal LUFS={:.2f}) for input={:s} '
+            'output={:s}'.format(gain_amount, goal_lufs, infile, outfile))

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -1589,4 +1589,7 @@ class Scaper(object):
                                row.value['label']])
                     df.loc[len(df)] = newrow
 
+            # sort events by onset time
+            df = df.sort_values('onset')
+            df.reset_index(inplace=True, drop=True)
             df.to_csv(txt_path, index=False, header=False, sep=' ')

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -86,7 +86,7 @@ def generate_from_jams(jams_infile, audio_outfile, fg_path=None, bg_path=None,
     if fg_path is None:
         new_fg_path = ann.sandbox.scaper['fg_path']
     else:
-        new_fg_path = fg_path
+        new_fg_path = os.path.expanduser(fg_path)
         # Update source files
         for idx in ann.data.index:
             if ann.data.loc[idx, 'value']['role'] == 'foreground':
@@ -95,7 +95,7 @@ def generate_from_jams(jams_infile, audio_outfile, fg_path=None, bg_path=None,
                 parent = os.path.dirname(sourcefile)
                 parentname = os.path.basename(parent)
                 newsourcefile = os.path.join(
-                    fg_path, parentname, sourcefilename)
+                    new_fg_path, parentname, sourcefilename)
                 ann.data.loc[idx, 'value']['source_file'] = newsourcefile
         # Update sandbox
         ann.sandbox.scaper['fg_path'] = new_fg_path
@@ -103,7 +103,7 @@ def generate_from_jams(jams_infile, audio_outfile, fg_path=None, bg_path=None,
     if bg_path is None:
         new_bg_path = ann.sandbox.scaper['bg_path']
     else:
-        new_bg_path = bg_path
+        new_bg_path = os.path.expanduser(bg_path)
         # Update source files
         for idx in ann.data.index:
             if ann.data.loc[idx, 'value']['role'] == 'background':
@@ -112,7 +112,7 @@ def generate_from_jams(jams_infile, audio_outfile, fg_path=None, bg_path=None,
                 parent = os.path.dirname(sourcefile)
                 parentname = os.path.basename(parent)
                 newsourcefile = os.path.join(
-                    bg_path, parentname, sourcefilename)
+                    new_bg_path, parentname, sourcefilename)
                 ann.data.loc[idx, 'value']['source_file'] = newsourcefile
         # Update sandbox
         ann.sandbox.scaper['bg_path'] = new_bg_path
@@ -756,10 +756,12 @@ class Scaper(object):
         self.bg_spec = []
 
         # Validate paths and set
-        _validate_folder_path(fg_path)
-        _validate_folder_path(bg_path)
-        self.fg_path = fg_path
-        self.bg_path = bg_path
+        expanded_fg_path = os.path.expanduser(fg_path)
+        expanded_bg_path = os.path.expanduser(bg_path)
+        _validate_folder_path(expanded_fg_path)
+        _validate_folder_path(expanded_bg_path)
+        self.fg_path = expanded_fg_path
+        self.bg_path = expanded_bg_path
 
         # Populate label lists from folder paths
         self.fg_labels = []

--- a/scaper/util.py
+++ b/scaper/util.py
@@ -256,8 +256,8 @@ def polyphony_gini(ann, hop_size=0.01):
         return 0
 
     # Sample the polyphony using the specified hop size
-    n_samples = np.floor(ann.duration / float(hop_size)) + 1
-    times = np.linspace(0, n_samples * hop_size, n_samples)
+    n_samples = int(np.floor(ann.duration / float(hop_size)) + 1)
+    times = np.linspace(0, (n_samples-1) * hop_size, n_samples)
     values = np.zeros_like(times)
 
     for idx in ann.data.index:
@@ -266,8 +266,14 @@ def polyphony_gini(ann, hop_size=0.01):
             end_time = (
                 start_time + ann.data.loc[idx, 'duration'].total_seconds())
             start_idx = np.argmin(np.abs(times - start_time))
-            end_idx = np.argmin(np.abs(times - end_time))
+            end_idx = np.argmin(np.abs(times - end_time)) - 1
             values[start_idx:end_idx + 1] += 1
+    values = values[:-1]
+
+    # DEBUG
+    # vstring = ('{:d} ' * len(values)).format(*tuple([int(v) for v in values]))
+    # print(vstring)
+    # print(' ')
 
     # Compute gini as per:
     # http://www.statsdirect.com/help/default.htm#nonparametric_methods/gini.htm

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -64,5 +64,7 @@ def test_scaper_add_background():
                                   event_time=("const", 0),
                                   event_duration=("const", sc.duration),
                                   snr=("const", 0),
-                                  role='background')
+                                  role='background',
+                                  pitch_shift=None,
+                                  time_stretch=None)
     assert sc.bg_spec == [bg_event_expected]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -138,7 +138,9 @@ def test_max_polyphony():
                                            event_time=ind / 2.,
                                            event_duration=10,
                                            snr=0,
-                                           role='foreground')
+                                           role='foreground',
+                                           pitch_shift=None,
+                                           time_stretch=None)
 
             ann.append(time=ind / 2.,
                        duration=10,
@@ -159,7 +161,9 @@ def test_max_polyphony():
                                            event_time=ind * 10,
                                            event_duration=5,
                                            snr=0,
-                                           role='foreground')
+                                           role='foreground',
+                                           pitch_shift=None,
+                                           time_stretch=None)
 
             ann.append(time=ind * 10,
                        duration=5,


### PR DESCRIPTION
Add support for foreground event pitch shifting and time stretching on the fly. Originally I thought this would be implemented via MUDA, but it turns out it's possible to implement this via sox directly, and actually simpler given the existing dependency on sox.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/justinsalamon/scaper/12)
<!-- Reviewable:end -->
