### PR TITLE
Increase min sox to v1.3.3 to fix windows bug

### DIFF
--- a/scaper/version.py
+++ b/scaper/version.py
@@ -3,4 +3,4 @@
 """Version info"""
 
 short_version = '0.1'
-version = '0.1.0'
+version = '0.1.1'

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
             "Programming Language :: Python :: 3.6",
         ],
     install_requires=[
-        'sox>=1.3.0',
+        'sox>=1.3.3',
         'jams==0.2.2',
         'pandas==0.19.2'
     ],


### PR DESCRIPTION
Increase minimum sox version to 1.3.3, this version includes a fix to a bug in pysox that caused it to crash on windows (and consequently scaper too). Bump scaper version to 0.1.1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/justinsalamon/scaper/26)
<!-- Reviewable:end -->
