### PR TITLE
Compute post-padding based on actual stretched duration instead of estimated

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,21 @@
 Changelog
 ---------
 
+v1.0.1
+~~~~~~
+- Fix bug where estimated duration of time stretched event is different to actual duration leading to incorrect silence padding and sometimes incorrect soundscape duration (in audio samples).
+
+v1.0.0
+~~~~~~
+- Major revision
+- Support jams>=0.3
+- Switch from the sound_event to the scaper namespace.
+- While the API remains compatible with previous versions, the change of underlying namespace breaks compatibility with jams files created using scaper for versions <1.0.0.
+
+v0.2.1
+~~~~~~
+- Fix bug related to creating temp files on Windows.
+
 v0.2.0
 ~~~~~~
 - :pr:`28`: Improve LUFS calculation:

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -1562,6 +1562,10 @@ class Scaper(object):
                             # synthesize edited foreground sound event
                             tfm.build(e.value['source_file'],
                                       tmpfiles_internal[-1].name)
+                            # if time stretched get actual new duration
+                            if e.value['time_stretch'] is not None:
+                                fg_stretched_duration = sox.file_info.duration(
+                                    tmpfiles_internal[-1].name)
 
                             # NOW compute LUFS
                             fg_lufs = get_integrated_lufs(
@@ -1585,8 +1589,7 @@ class Scaper(object):
                                 postpad = max(
                                     0, self.duration - (
                                             e.value['event_time'] +
-                                            e.value['event_duration'] *
-                                            e.value['time_stretch']))
+                                            fg_stretched_duration))
                             tfm.pad(prepad, postpad)
 
                             # Finally save result to a tmp file

--- a/scaper/version.py
+++ b/scaper/version.py
@@ -3,4 +3,4 @@
 """Version info"""
 
 short_version = '1.0'
-version = '1.0.0'
+version = '1.0.1'


### PR DESCRIPTION
Avoid bug where post-padding adds too many samples of silence since estimated stretched duration diverges slightly (on the order of 1e-04) from the actually stretched duration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/justinsalamon/scaper/45)
<!-- Reviewable:end -->
