### PR TITLE
Close tmpfiles on error

### DIFF
--- a/scaper/util.py
+++ b/scaper/util.py
@@ -27,14 +27,20 @@ def _close_temp_files(tmpfiles):
         List of temporary file handles
 
     '''
+    def _close():
+        for t in tmpfiles:
+            try:
+                t.close()
+                os.unlink(t.name)
+            except:
+                pass
+    try:
+        yield
+    except:
+        _close()
+        raise
+    _close()
 
-    yield
-    for t in tmpfiles:
-        try:
-            t.close()
-            os.unlink(t.name)
-        except:
-            pass
 
 
 @contextmanager

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -68,6 +68,20 @@ def test_close_temp_files():
         assert tf.file.closed
         assert not os.path.isfile(tf.name)
 
+    # with an exception before exiting
+    try:
+        tmpfiles = []
+        with _close_temp_files(tmpfiles):
+            tmpfiles.append(
+                tempfile.NamedTemporaryFile(suffix='.wav', delete=True))
+            raise ScaperError
+    except ScaperError:
+        for tf in tmpfiles:
+            assert tf.file.closed
+            assert not os.path.isfile(tf.name)
+    else:
+        assert False, 'Exception was not reraised.'
+
 
 def test_set_temp_logging_level():
     '''


### PR DESCRIPTION
Close tmpfiles if an exception is raised before exiting `_close_tmp_files`

This is in reference to #50 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/justinsalamon/scaper/49)
<!-- Reviewable:end -->
