### PR TITLE
Should be able to seed Scaper generation for reproducibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/*
 docs/_build/*
 scaper/bin/*
 .pytest_cache/*
+**/.DS_Store

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,13 @@
 Changelog
 ---------
 
+v1.2.0
+~~~~~~
+- Added a random_state parameter to Scaper object, which allows all runs to be perfectly reproducible given the same audio and the same random seed.
+- Switched from numpydoc to napoleon for generating the documentation. Also switched Sphinx to the most recent version.
+- Added functions to Scaper object that allow one to reset the foreground and background event specifications independently. This allows users to reuse the same Scaper object and generate multiple soundscapes.
+- Added a function to Scaper that allows the user to set the random state after creation.
+
 v1.1.0
 ~~~~~~
 - Added functionality which modifies a source_time distribution tuple according to the duration of the source and the duration of the event.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,7 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
-    'numpydoc',
+    'sphinx.ext.napoleon',
     'sphinx_issues'
 ]
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -48,16 +48,24 @@ Example: synthesizing 1000 soundscapes in one go
     time_stretch_min = 0.8
     time_stretch_max = 1.2
 
+    # generate a random seed for this Scaper object
+    seed = 123
+
+    # create a scaper that will be used below
+    sc = scaper.Scaper(duration, fg_folder, bg_folder, random_state=seed)
+    sc.protected_labels = []
+    sc.ref_db = ref_db
+
     # Generate 1000 soundscapes using a truncated normal distribution of start times
 
     for n in range(n_soundscapes):
 
         print('Generating soundscape: {:d}/{:d}'.format(n+1, n_soundscapes))
 
-        # create a scaper
-        sc = scaper.Scaper(duration, fg_folder, bg_folder)
-        sc.protected_labels = []
-        sc.ref_db = ref_db
+        # reset the event specifications for foreground and background at the 
+        # beginning of each loop to clear all previously added events
+        sc.reset_bg_spec()
+        sc.reset_fg_spec()
 
         # add background
         sc.add_background(label=('const', 'noise'),

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -100,6 +100,46 @@ when we add foreground events, we'll have to specify an ``snr``
 be louder (or softer) with respect to the background level specified by
 ``sc.ref_db``.
 
+Seeding the Scaper object for reproducibility
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A further argument can be specified to the ``Scaper`` object:
+
+- The random state: this can be either a numpy.random.RandomState object or an integer.
+  In the latter case, a random state will be constructed. The random state is what will 
+  be used for drawing from any distributions. If the audio kept in all of the folders is
+  exactly the same and the random state is fixed between runs, the same soundscape will be 
+  generated both times. If you don't define any random state or set seed to None, runs 
+  will be random and not reproducible. You can use np.random.get_state() to reproduce 
+  the run after the fact by recording the seed that was used somewhere.
+
+This can be specified like so (e.g. for a random seed of 0):
+
+.. code-block:: python
+
+    import scaper
+    import os
+    soundscape_duration = 10.0
+    seed = 123
+    foreground_folder = os.path.expanduser('~/audio/foreground/')
+    background_folder = os.path.expanduser('~/audio/background/')
+    sc = scaper.Scaper(soundscape_duration, foreground_folder, background_folder, 
+                       random_state=seed)
+    sc.ref_db = -20
+
+If the random state is not specified, it defaults to the old behavior which just uses
+the RandomState used by np.random. You can also set the random state after creation
+via ``Scaper.set_random_state``. Alternatively, you can set the random state directly:
+
+.. code-block:: python
+
+    import numpy as np
+    seed = np.random.RandomState(123)
+    sc = scaper.Scaper(soundscape_duration, foreground_folder, background_folder, 
+                       random_state=seed)
+    sc.ref_db = -20
+
+
 Adding a background and foreground sound events
 -----------------------------------------------
 

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -849,6 +849,36 @@ class Scaper(object):
     '''
 
     def __init__(self, duration, fg_path, bg_path, protected_labels=[], random_state=None):
+        '''
+        Create a Scaper object.
+
+        Parameters
+        ----------
+        duration : float
+            Duration of the soundscape, in seconds.
+        fg_path : str
+            Path to foreground folder.
+        bg_path : str
+            Path to background folder.
+        protected_labels : list 
+            Provide a list of protected foreground labels. When a foreground
+            label is in the protected list it means that when a sound event
+            matching the label gets added to a soundscape instantiation the
+            duration of the source audio file cannot be altered, and the
+            duration value that was provided in the specification will be
+            ignored. Adding labels to the protected list is useful for sound events
+            whose semantic validity would be lost if the sound were trimmed
+            before the sound event ends, for example an animal vocalization
+            such as a dog bark.
+        random_state : int, RandomState instance or None, optional (default=None)
+            If int, random_state is the seed used by the random number 
+            generator; If RandomState instance, random_state is the random number 
+            generator; If None, the random number generator is the RandomState 
+            instance used by np.random. Note that if the random state is passed as a 
+            RandomState instance, it is passed by reference, not value. This will lead to
+            the Scaper object advancing the state of the random state object if you use
+            it elsewhere.
+        '''
         # Duration must be a positive real number
         if np.isrealobj(duration) and duration > 0:
             self.duration = duration

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -24,6 +24,7 @@ from .util import is_real_number, is_real_array
 from .audio import get_integrated_lufs
 from .version import version as scaper_version
 
+# TODO: for seeding, turn these into more complex functions in util?
 SUPPORTED_DIST = {"const": lambda x: x,
                   "choose": lambda x: random.choice(x),
                   "uniform": random.uniform,
@@ -245,7 +246,7 @@ def trim(audio_infile, jams_infile, audio_outfile, jams_outfile, start_time,
                 # Copy result back to original file
                 shutil.copyfile(tmpfiles[-1].name, audio_outfile)
 
-
+# TODO: this should take a np.RandomSeed object (default to None)
 def _get_value_from_dist(dist_tuple):
     '''
     Sample a value from the provided distribution tuple.
@@ -812,7 +813,7 @@ def _validate_event(label, source_file, source_time, event_time,
     # Time stretch
     _validate_time_stretch(time_stretch)
 
-
+# TODO: add a seed parameter in init that defaults to None
 class Scaper(object):
     '''
     Create a Scaper object.

--- a/scaper/util.py
+++ b/scaper/util.py
@@ -148,7 +148,7 @@ def _populate_label_list(folder_path, label_list):
     # ensure consistent ordering of labels
     label_list.sort()
 
-
+# TODO: add a seed parameter here for seeding
 def _trunc_norm(mu, sigma, trunc_min, trunc_max):
     '''
     Return a random value sampled from a truncated normal distribution with

--- a/scaper/util.py
+++ b/scaper/util.py
@@ -9,8 +9,12 @@ import logging
 import os
 import glob
 from .scaper_exceptions import ScaperError
+import warnings
+from .scaper_warnings import ScaperWarning
 import scipy
 import numpy as np
+import numbers
+from copy import deepcopy
 
 
 @contextmanager
@@ -148,8 +152,128 @@ def _populate_label_list(folder_path, label_list):
     # ensure consistent ordering of labels
     label_list.sort()
 
-# TODO: add a seed parameter here for seeding
-def _trunc_norm(mu, sigma, trunc_min, trunc_max):
+
+def _check_random_state(seed):
+    """Turn seed into a np.random.RandomState instance
+
+    Parameters
+    ----------
+    seed : None | int | instance of RandomState
+        If seed is None, return the RandomState singleton used by np.random.
+        If seed is an int, return a new RandomState instance seeded with seed.
+        If seed is already a RandomState instance, return it.
+        Otherwise raise ValueError.
+    """
+    if seed is None or seed is np.random:
+        return np.random.mtrand._rand
+    elif isinstance(seed, (numbers.Integral, np.integer, int)):
+        return np.random.RandomState(seed)
+    elif isinstance(seed, np.random.RandomState):
+        return seed
+    else:
+        raise ValueError('%r cannot be used to seed a numpy.random.RandomState'
+                         ' instance' % seed)
+
+
+def _sample_const(item, random_state):
+    '''
+    Return a value sampled from a constant distribution (just the item).
+
+    Parameters
+    ----------
+    item : any
+        What to return
+    random_state : mtrand.RandomState
+        RandomState object used to sample from this distribution (ignored).
+        This is here to match the other function specifications.
+
+    Returns
+    -------
+    value : any
+        item, returned.
+
+    '''
+    return item
+
+
+def _sample_uniform(minimum, maximum, random_state):
+    '''
+    Return a random value sampled from a uniform distribution 
+    between ```minimum``` and ```maximum```.
+
+    Parameters
+    ----------
+    minimum : float
+        Minimum of uniform distribution
+    maximum : float
+        Maximum of uniform distribution
+    random_state : mtrand.RandomState
+        RandomState object used to sample from this distribution.
+
+    Returns
+    -------
+    value : float
+        A random value sampled from the uniform distribution defined
+        by ```minimum```, ```maximum```.
+
+    '''
+    return random_state.uniform(minimum, maximum)
+
+
+def _sample_normal(mu, sigma, random_state):
+    '''
+    Return a random value sampled from a normal distribution with
+    mean ```mu``` and standard deviation ```sigma```.
+
+    Parameters
+    ----------
+    mu : float
+        The mean of the truncated normal distribution
+    sig : float
+        The standard deviation of the truncated normal distribution
+    random_state : mtrand.RandomState
+        RandomState object used to sample from this distribution.
+
+    Returns
+    -------
+    value : float
+        A random value sampled from the normal distribution defined
+        by ```mu```, ```sigma```.
+
+    '''
+    return random_state.normal(mu, sigma)
+
+
+def _sample_choose(list_of_options, random_state):
+    '''
+    Return a random item from ```list_of_options```, using random_state.
+    If there are duplicates in ```list_of_options```, we remove them from the 
+    list before sampling an item from the list.
+
+    Parameters
+    ----------
+    list_of_options : list
+        List of items to choose from.
+    random_state : mtrand.RandomState
+        RandomState object used to sample from this distribution.
+
+    Returns
+    -------
+    value : any
+        A random item chosen from ```list_of_options```.
+
+    '''
+    new_list_of_options = list(set(list_of_options))
+    if len(new_list_of_options) < len(list_of_options):
+        warnings.warn(
+            'Removed duplicates from choose list. List length changed '
+            'from {:d} to {:d}'.format(len(list_of_options), len(new_list_of_options)),
+            ScaperWarning)
+    index = random_state.randint(len(new_list_of_options))
+    return new_list_of_options[index]
+
+
+def _sample_trunc_norm(mu, sigma, trunc_min, trunc_max, random_state):
     '''
     Return a random value sampled from a truncated normal distribution with
     mean ```mu``` and standard deviation ```sigma``` whose values are limited
@@ -165,6 +289,8 @@ def _trunc_norm(mu, sigma, trunc_min, trunc_max):
         The minimum value allowed for the distribution (lower boundary)
     trunc_max : float
         The maximum value allowed for the distribution (upper boundary)
+    random_state : mtrand.RandomState
+        RandomState object used to sample from this distribution.
 
     Returns
     -------
@@ -178,7 +304,7 @@ def _trunc_norm(mu, sigma, trunc_min, trunc_max):
     # values for a standard normal distribution (mu=0, sigma=1), so we need
     # to recompute a and b given the user specified parameters.
     a, b = (trunc_min - mu) / float(sigma), (trunc_max - mu) / float(sigma)
-    return scipy.stats.truncnorm.rvs(a, b, mu, sigma)
+    return scipy.stats.truncnorm.rvs(a, b, mu, sigma, random_state=random_state)
 
 
 def max_polyphony(ann):

--- a/scaper/version.py
+++ b/scaper/version.py
@@ -2,5 +2,5 @@
 # -*- coding: utf-8 -*-
 """Version info"""
 
-short_version = '1.1'
-version = '1.1.0'
+short_version = '1.2'
+version = '1.2.0'

--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,9 @@ setup(
     ],
     extras_require={
         'docs': [
-                'sphinx==1.2.3',  # autodoc was broken in 1.3.1
-                'sphinxcontrib-napoleon',
+                'sphinx',  # autodoc was broken in 1.3.1
                 'sphinx_rtd_theme',
-                'numpydoc',
+                'sphinx_issues',
             ],
         'tests': ['backports.tempfile', 'pysoundfile']
     }


### PR DESCRIPTION
We should be able to seed Scaper so that multiple runs with the same seed on the same underlying data yield the exact same mixtures. Addresses #36.

For now, I've just placed TODOs.

Will try to follow the discussion in #36 when implementing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/justinsalamon/scaper/54)
<!-- Reviewable:end -->
