### PR TITLE
Fix for #84

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,11 @@
 
 Changelog
 ---------
+v.1.3.2
+~~~~~~~
+- Fixed a bug with generating the file names when saving the isolated events. The idx for
+  background and foreground events now increment separately.
+
 v.1.3.1
 ~~~~~~~
 - Fixed a bug with generating docs on ReadTheDocs.

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -1688,6 +1688,8 @@ class Scaper(object):
             with _close_temp_files(tmpfiles):
                 isolated_events_audio_path = []
 
+                role_counter = {'background': 0, 'foreground': 0}
+
                 for i, e in enumerate(ann.data):
                     if e.value['role'] == 'background':
                         # Concatenate background if necessary. Right now we
@@ -1827,10 +1829,13 @@ class Scaper(object):
                         else:
                             event_folder = isolated_events_path
 
+                        _role_count = role_counter[e.value['role']]
                         event_audio_path = os.path.join(
                             event_folder, 
                             '{:s}{:d}_{:s}{:s}'.format(
-                                e.value['role'], i, e.value['label'], ext))
+                                e.value['role'], _role_count, e.value['label'], ext))
+                        role_counter[e.value['role']] += 1
+                        
                         if not os.path.exists(event_folder):
                             # In Python 3.2 and above we could do 
                             # os.makedirs(..., exist_ok=True) but we test back to

--- a/scaper/version.py
+++ b/scaper/version.py
@@ -3,4 +3,4 @@
 """Version info"""
 
 short_version = '1.3'
-version = '1.3.1'
+version = '1.3.2'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1464,16 +1464,30 @@ def _test_generate_isolated_events(SR, isolated_events_path=None, atol=1e-4, rto
             # event_audio contains the path to the actual audio
 
             # make sure the path matches the event description
-
-            look_for = '{:s}{:d}_{:s}'.format(
+            look_for = '{:s}{:d}_{:s}.wav'.format(
                 event_spec.value['role'], 
                 role_counter[event_spec.value['role']],
                 event_spec.value['label']
             )
-            assert look_for in event_audio_path
+
+            expected_path = os.path.join(isolated_events_path, look_for)
+            # make sure the path exists
+            assert os.path.exists(expected_path)
+
+            # make sure what's in the sandbox also exists
+            assert os.path.exists(event_audio_path)
+            # is an audio file with the same contents as what we expect
+            _isolated_expected_audio, sr = soundfile.read(expected_path)
+            _isolated_sandbox_audio, sr = soundfile.read(event_audio_path)
+            assert np.allclose(_isolated_sandbox_audio, _isolated_expected_audio)
+
+            # make sure the filename matches
+            assert look_for == os.path.basename(event_audio_path)
+
+            # increment for the next role
             role_counter[event_spec.value['role']] += 1
 
-            isolated_audio.append(soundfile.read(event_audio_path)[0])
+            isolated_audio.append(_isolated_sandbox_audio)
 
         # the sum of the isolated audio should sum to the soundscape
         assert np.allclose(sum(isolated_audio), soundscape_audio, atol=1e-4, rtol=1e-8)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1454,13 +1454,25 @@ def _test_generate_isolated_events(SR, isolated_events_path=None, atol=1e-4, rto
         isolated_event_audio_paths = ann.sandbox.scaper.isolated_events_audio_path
         isolated_audio = []
 
+        role_counter = {
+            'background': 0,
+            'foreground': 0
+        }
+
         for event_spec, event_audio_path in zip(ann, isolated_event_audio_paths):
             # event_spec contains the event description, label, etc
             # event_audio contains the path to the actual audio
 
             # make sure the path matches the event description
-            assert event_spec.value['role'] in event_audio_path
-            assert event_spec.value['label'] in event_audio_path
+
+            look_for = '{:s}{:d}_{:s}'.format(
+                event_spec.value['role'], 
+                role_counter[event_spec.value['role']],
+                event_spec.value['label']
+            )
+            assert look_for in event_audio_path
+            role_counter[event_spec.value['role']] += 1
+
             isolated_audio.append(soundfile.read(event_audio_path)[0])
 
         # the sum of the isolated audio should sum to the soundscape


### PR DESCRIPTION
This should fix #84. The test is now strengthened (Scaper 1.3.1 fails). The new test looks explicitly for the role, the background or foreground idx, and the label in the generated file.