### PR TITLE
Fix for #87

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,11 @@
 
 Changelog
 ---------
+v.1.3.3
+~~~~~~~
+- Fixed a bug with the format and subtype of audio files not being maintained in 
+  match_sample_length.
+
 v.1.3.2
 ~~~~~~~
 - Fixed a bug with generating the file names when saving the isolated events. The idx for

--- a/scaper/audio.py
+++ b/scaper/audio.py
@@ -134,8 +134,8 @@ def match_sample_length(audio_path, duration_in_samples):
             'Duration in samples must be an integer.')
 
     audio, sr = soundfile.read(audio_path)
+    audio_info = soundfile.info(audio_path)
     current_duration = audio.shape[0]
-    old_shape = audio.shape
 
     if duration_in_samples < current_duration:
         audio = audio[:duration_in_samples]
@@ -147,4 +147,5 @@ def match_sample_length(audio_path, duration_in_samples):
 
         audio = np.pad(audio, pad_width, 'constant')
 
-    soundfile.write(audio_path, audio, sr)
+    soundfile.write(audio_path, audio, sr, 
+        subtype=audio_info.subtype, format=audio_info.format)

--- a/scaper/version.py
+++ b/scaper/version.py
@@ -3,4 +3,4 @@
 """Version info"""
 
 short_version = '1.3'
-version = '1.3.2'
+version = '1.3.3'

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -54,13 +54,18 @@ def test_get_integrated_lufs():
 
 def change_format_and_subtype(audio_path):
     audio, sr = sf.read(audio_path)
+    audio_info = sf.info(audio_path)
 
     formats = ['WAV', 'FLAC']
+    if audio_info.format in formats:
+        formats.remove(audio_info.format)
     _format = random.choice(formats)
 
     subtypes = sf.available_subtypes(_format)
     accepted_subtypes = ['PCM_16', 'PCM_32', 'PCM_24', 'FLOAT', 'DOUBLE']
     subtypes = [s for s in subtypes.keys() if s in accepted_subtypes]
+    if audio_info.subtype in subtypes:
+        subtypes.remove(audio_info.subtype)
     _subtype = random.choice(subtypes)
     
     sf.write(audio_path, audio, sr, subtype=_subtype, format=_format)


### PR DESCRIPTION
This fix is for #87. The change is in `match_sample_length` to maintain the format of the original audio file when writing it back to disk. The test was updated to test for this explicitly. I test that the format is maintained across the following subtypes and formats available in soundfile:

```
formats = ['WAV', 'FLAC']
accepted_subtypes = ['PCM_16', 'PCM_32', 'PCM_24', 'FLOAT', 'DOUBLE']
```

I'm not sure what happens under the hood for subtypes and formats not in this list not every subtype/format worked - some of the formats are really esoteric. Here's the full list of soundfile formats:

```
{'AIFF': 'AIFF (Apple/SGI)', 'AU': 'AU (Sun/NeXT)', 
'AVR': 'AVR (Audio Visual Research)',
 'CAF': 'CAF (Apple Core Audio File)', 
'FLAC': 'FLAC (Free Lossless Audio Codec)',
 'HTK': 'HTK (HMM Tool Kit)', 
'SVX': 'IFF (Amiga IFF/SVX8/SV16)', 
'MAT4': 'MAT4 (GNU Octave 2.0 / Matlab 4.2)', 
'MAT5': 'MAT5 (GNU Octave 2.1 / Matlab 5.0)', 
'MPC2K': 'MPC (Akai MPC 2k)',
'OGG': 'OGG (OGG Container format)', 
'PAF': 'PAF (Ensoniq PARIS)', 
'PVF': 'PVF (Portable Voice Format)', 
'RAW': 'RAW (header-less)', 
'RF64': 'RF64 (RIFF 64)', 
'SD2': 'SD2 (Sound Designer II)', 
'SDS': 'SDS (Midi Sample Dump Standard)', 
'IRCAM': 'SF (Berkeley/IRCAM/CARL)',
 'VOC': 'VOC (Creative Labs)', 
'W64': 'W64 (SoundFoundry WAVE 64)', 
'WAV': 'WAV (Microsoft)', 
'NIST': 'WAV (NIST Sphere)', 
'WAVEX': 'WAVEX (Microsoft)',
'WVE': 'WVE (Psion Series 3)', 
'XI': 'XI (FastTracker 2)'}
```

And subtypes:

```
{'PCM_16': 'Signed 16 bit PCM', 'PCM_24': 'Signed 24 bit PCM', 
'PCM_32': 'Signed 32 bit PCM', 'PCM_U8': 'Unsigned 8 bit PCM',
 'FLOAT': '32 bit float', 'DOUBLE': '64 bit float', 
'ULAW': 'U-Law', 'ALAW': 'A-Law', 'IMA_ADPCM': 
'IMA ADPCM', 'MS_ADPCM': 'Microsoft ADPCM', 
'GSM610': 'GSM 6.10', 'G721_32': '32kbs G721 ADPCM'}
```

In general though, it seems that Scaper is not built explicitly for non-wav audio files and behavior on those is (afaik) undetermined. It's definitely not tested for. I think we can push a fix now to this and open a new issue for dealing with audio files that are not wav files in Scaper.