### PR TITLE
Fix for #73 - off by one errors

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,9 +4,11 @@ Changelog
 ---------
 v.1.3.4
 ~~~~~~~
-- Fixed a bug where the soundscapes were off by one sample when generated. Added a
-  field to the sandbox that keeps track of the original duration of the soundscape 
-  before any trimming is applied.
+- Fixed a bug where the soundscapes were off by one sample when generated. Fixes bug 
+  where generating from jams using a trimmed jams file was using the trimmed soundscape 
+  duration instead of the original duration.
+- Added a field to the sandbox that keeps track of the original duration of the 
+  soundscape before any trimming is applied.
 
 v.1.3.3
 ~~~~~~~

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,12 @@
 
 Changelog
 ---------
+v.1.3.4
+~~~~~~~
+- Fixed a bug where the soundscapes were off by one sample when generated. Added a
+  field to the sandbox that keeps track of the original duration of the soundscape 
+  before any trimming is applied.
+
 v.1.3.3
 ~~~~~~~
 - Fixed a bug with the format and subtype of audio files not being maintained in 

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -152,7 +152,7 @@ def generate_from_jams(jams_infile, audio_outfile, fg_path=None, bg_path=None,
         warnings.warn(
             "Couldn't find original_duration field in the scaper sandbox, "
             "using duration field instead. This can lead to incorrect behavior "
-            "if generating from a jams file that has been trimmed previously",
+            "if generating from a jams file that has been trimmed previously.",
             ScaperWarning)
     
     protected_labels = ann.sandbox.scaper['protected_labels']

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -1675,7 +1675,6 @@ class Scaper(object):
         Scaper.generate
 
         '''
-        success = True
         if ann.namespace != 'scaper':
             raise ScaperError(
                 'Annotation namespace must be scaper, found: {:s}'.format(
@@ -1888,7 +1887,6 @@ class Scaper(object):
         
         ann.sandbox.scaper.soundscape_audio_path = audio_path
         ann.sandbox.scaper.isolated_events_audio_path = isolated_events_audio_path
-        return success
 
     def generate(self, audio_path, jams_path, allow_repeated_label=True,
                  allow_repeated_source=True,reverb=None, save_isolated_events=False, 

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -149,6 +149,11 @@ def generate_from_jams(jams_infile, audio_outfile, fg_path=None, bg_path=None,
         duration = ann.sandbox.scaper['original_duration']
     else:
         duration = ann.sandbox.scaper['duration']
+        warnings.warn(
+            "Couldn't find original_duration field in the scaper sandbox, "
+            "using duration field instead. This can lead to incorrect behavior "
+            "if generating from a jams file that has been trimmed previously",
+            ScaperWarning)
     
     protected_labels = ann.sandbox.scaper['protected_labels']
     sc = Scaper(duration, new_fg_path, new_bg_path, protected_labels)

--- a/scaper/version.py
+++ b/scaper/version.py
@@ -3,4 +3,4 @@
 """Version info"""
 
 short_version = '1.3'
-version = '1.3.3'
+version = '1.3.4'

--- a/tests/data/regression/bgonly_soundscape_20170928.jams
+++ b/tests/data/regression/bgonly_soundscape_20170928.jams
@@ -92,6 +92,7 @@
           "fg_spec": [],
           "polyphony_gini": 0,
           "duration": 10.0,
+          "original_duration": 10.0,
           "bg_labels": [
             "park",
             "restaurant",

--- a/tests/data/regression/bgonly_soundscape_20190326_22050.jams
+++ b/tests/data/regression/bgonly_soundscape_20190326_22050.jams
@@ -36,6 +36,7 @@
       "sandbox": {
         "scaper": {
           "duration": 10.0,
+          "original_duration": 10.0,
           "fg_path": "tests/data/audio/foreground",
           "bg_path": "tests/data/audio/background",
           "fg_spec": [],

--- a/tests/data/regression/reverb_soundscape_20170928.jams
+++ b/tests/data/regression/reverb_soundscape_20170928.jams
@@ -234,6 +234,7 @@
           ],
           "polyphony_gini": 0.5422979845375607,
           "duration": 10.0,
+          "original_duration": 10.0,
           "bg_labels": [
             "park",
             "restaurant",

--- a/tests/data/regression/reverb_soundscape_20190326_22050.jams
+++ b/tests/data/regression/reverb_soundscape_20190326_22050.jams
@@ -84,6 +84,7 @@
       "sandbox": {
         "scaper": {
           "duration": 10.0,
+          "original_duration": 10.0,
           "fg_path": "tests/data/audio/foreground",
           "bg_path": "tests/data/audio/background",
           "fg_spec": [

--- a/tests/data/regression/scaper_133_off_by_one_regression_test.jams
+++ b/tests/data/regression/scaper_133_off_by_one_regression_test.jams
@@ -1,0 +1,410 @@
+{
+  "annotations": [
+    {
+      "annotation_metadata": {
+        "curator": {
+          "name": "",
+          "email": ""
+        },
+        "annotator": {},
+        "version": "",
+        "corpus": "",
+        "annotation_tools": "",
+        "annotation_rules": "",
+        "validation": "",
+        "data_source": ""
+      },
+      "namespace": "scaper",
+      "data": [
+        {
+          "time": 0.0,
+          "duration": 10.0,
+          "value": {
+            "label": "restaurant",
+            "source_file": "tests/data/audio/background/restaurant/207208__jormarp__high-street-of-gandia-valencia-spain_trimmed.wav",
+            "source_time": 0,
+            "event_time": 0,
+            "event_duration": 10,
+            "snr": 0,
+            "role": "background",
+            "pitch_shift": null,
+            "time_stretch": null
+          },
+          "confidence": 1.0
+        },
+        {
+          "time": 0.1515451373079606,
+          "duration": 0.7624999125537036,
+          "value": {
+            "label": "human_voice",
+            "source_file": "tests/data/audio/foreground/human_voice/42-Human-Vocal-Voice-taxi-2_edit.wav",
+            "source_time": 0,
+            "event_time": 0.1515451373079606,
+            "event_duration": 0.806236,
+            "snr": 11.918218682863063,
+            "role": "foreground",
+            "pitch_shift": -0.5817063737910275,
+            "time_stretch": 0.9457527480213035
+          },
+          "confidence": 1.0
+        },
+        {
+          "time": 1.05803863224466,
+          "duration": 1.1561720604107506,
+          "value": {
+            "label": "human_voice",
+            "source_file": "tests/data/audio/foreground/human_voice/42-Human-Vocal-Voice-all-aboard_edit.wav",
+            "source_time": 0,
+            "event_time": 1.05803863224466,
+            "event_duration": 1,
+            "snr": 18.108357788989466,
+            "role": "foreground",
+            "pitch_shift": -0.819305469847484,
+            "time_stretch": 1.1561720604107506
+          },
+          "confidence": 1.0
+        },
+        {
+          "time": 5.511352164646518,
+          "duration": 1.2450051039829642,
+          "value": {
+            "label": "car_horn",
+            "source_file": "tests/data/audio/foreground/car_horn/17-CAR-Rolls-Royce-Horn-2.wav",
+            "source_time": 0,
+            "event_time": 5.511352164646518,
+            "event_duration": 1.291678,
+            "snr": 10.384866887200525,
+            "role": "foreground",
+            "pitch_shift": 0.1815797734988669,
+            "time_stretch": 0.9638664620617243
+          },
+          "confidence": 1.0
+        },
+        {
+          "time": 6.291279533988657,
+          "duration": 1.406805819202459,
+          "value": {
+            "label": "car_horn",
+            "source_file": "tests/data/audio/foreground/car_horn/17-CAR-Rolls-Royce-Horn-2.wav",
+            "source_time": 0,
+            "event_time": 6.291279533988657,
+            "event_duration": 1.291678,
+            "snr": 16.70948168861533,
+            "role": "foreground",
+            "pitch_shift": -0.820383985868476,
+            "time_stretch": 1.0891304328187512
+          },
+          "confidence": 1.0
+        },
+        {
+          "time": 6.622096217654404,
+          "duration": 0.5514116613341726,
+          "value": {
+            "label": "car_horn",
+            "source_file": "tests/data/audio/foreground/car_horn/17-CAR-Rolls-Royce-Horn.wav",
+            "source_time": 0,
+            "event_time": 6.622096217654404,
+            "event_duration": 0.687506,
+            "snr": 17.592952736781164,
+            "role": "foreground",
+            "pitch_shift": -0.5419060155536417,
+            "time_stretch": 0.8020463258999524
+          },
+          "confidence": 1.0
+        }
+      ],
+      "sandbox": {
+        "scaper": {
+          "duration": 10,
+          "original_duration": 10,
+          "fg_path": "tests/data/audio/foreground",
+          "bg_path": "tests/data/audio/background",
+          "fg_spec": [
+            [
+              [
+                "choose",
+                []
+              ],
+              [
+                "choose",
+                []
+              ],
+              [
+                "const",
+                0
+              ],
+              [
+                "uniform",
+                0,
+                9
+              ],
+              [
+                "choose",
+                [
+                  1,
+                  2,
+                  3
+                ]
+              ],
+              [
+                "uniform",
+                10,
+                20
+              ],
+              "foreground",
+              [
+                "uniform",
+                -1,
+                1
+              ],
+              [
+                "uniform",
+                0.8,
+                1.2
+              ]
+            ],
+            [
+              [
+                "choose",
+                []
+              ],
+              [
+                "choose",
+                []
+              ],
+              [
+                "const",
+                0
+              ],
+              [
+                "uniform",
+                0,
+                9
+              ],
+              [
+                "choose",
+                [
+                  1,
+                  2,
+                  3
+                ]
+              ],
+              [
+                "uniform",
+                10,
+                20
+              ],
+              "foreground",
+              [
+                "uniform",
+                -1,
+                1
+              ],
+              [
+                "uniform",
+                0.8,
+                1.2
+              ]
+            ],
+            [
+              [
+                "choose",
+                []
+              ],
+              [
+                "choose",
+                []
+              ],
+              [
+                "const",
+                0
+              ],
+              [
+                "uniform",
+                0,
+                9
+              ],
+              [
+                "choose",
+                [
+                  1,
+                  2,
+                  3
+                ]
+              ],
+              [
+                "uniform",
+                10,
+                20
+              ],
+              "foreground",
+              [
+                "uniform",
+                -1,
+                1
+              ],
+              [
+                "uniform",
+                0.8,
+                1.2
+              ]
+            ],
+            [
+              [
+                "choose",
+                []
+              ],
+              [
+                "choose",
+                []
+              ],
+              [
+                "const",
+                0
+              ],
+              [
+                "uniform",
+                0,
+                9
+              ],
+              [
+                "choose",
+                [
+                  1,
+                  2,
+                  3
+                ]
+              ],
+              [
+                "uniform",
+                10,
+                20
+              ],
+              "foreground",
+              [
+                "uniform",
+                -1,
+                1
+              ],
+              [
+                "uniform",
+                0.8,
+                1.2
+              ]
+            ],
+            [
+              [
+                "choose",
+                []
+              ],
+              [
+                "choose",
+                []
+              ],
+              [
+                "const",
+                0
+              ],
+              [
+                "uniform",
+                0,
+                9
+              ],
+              [
+                "choose",
+                [
+                  1,
+                  2,
+                  3
+                ]
+              ],
+              [
+                "uniform",
+                10,
+                20
+              ],
+              "foreground",
+              [
+                "uniform",
+                -1,
+                1
+              ],
+              [
+                "uniform",
+                0.8,
+                1.2
+              ]
+            ]
+          ],
+          "bg_spec": [
+            [
+              [
+                "choose",
+                []
+              ],
+              [
+                "choose",
+                []
+              ],
+              [
+                "const",
+                0
+              ],
+              [
+                "const",
+                0
+              ],
+              [
+                "const",
+                10
+              ],
+              [
+                "const",
+                0
+              ],
+              "background",
+              null,
+              null
+            ]
+          ],
+          "fg_labels": [
+            "car_horn",
+            "human_voice",
+            "siren"
+          ],
+          "bg_labels": [
+            "park",
+            "restaurant",
+            "street"
+          ],
+          "protected_labels": [],
+          "sr": 44100,
+          "ref_db": -50,
+          "n_channels": 1,
+          "fade_in_len": 0.01,
+          "fade_out_len": 0.01,
+          "n_events": 5,
+          "polyphony_max": 3,
+          "polyphony_gini": 0.3438294065831903,
+          "allow_repeated_label": true,
+          "allow_repeated_source": true,
+          "reverb": null,
+          "scaper_version": "1.3.3",
+          "soundscape_audio_path": "/var/folders/5h/6vxlzhys259350xz4nb3xbym0000gn/T/tmpw80q7jsa.wav",
+          "isolated_events_audio_path": []
+        }
+      },
+      "time": 0,
+      "duration": 10
+    }
+  ],
+  "file_metadata": {
+    "title": "",
+    "artist": "",
+    "release": "",
+    "duration": 10,
+    "identifiers": {},
+    "jams_version": "0.3.3"
+  },
+  "sandbox": {}
+}

--- a/tests/data/regression/soundscape_20170928.jams
+++ b/tests/data/regression/soundscape_20170928.jams
@@ -234,6 +234,7 @@
           ],
           "polyphony_gini": 0.5422979845375607,
           "duration": 10.0,
+          "original_duration": 10.0,
           "bg_labels": [
             "park",
             "restaurant",

--- a/tests/data/regression/soundscape_20190326_22050.jams
+++ b/tests/data/regression/soundscape_20190326_22050.jams
@@ -84,6 +84,7 @@
       "sandbox": {
         "scaper": {
           "duration": 10.0,
+          "original_duration": 10.0,
           "fg_path": "tests/data/audio/foreground",
           "bg_path": "tests/data/audio/background",
           "fg_spec": [

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1656,3 +1656,5 @@ def test_backwards_compat_for_duration():
 
             assert np.allclose(orig_audio, gen_audio)
 
+            pytest.warns(ScaperWarning, scaper.generate_from_jams,
+                jam_without_orig_duration.name, gen_wav.name)


### PR DESCRIPTION
Fixing off by one errors in soundscape duration after generation. Happens very rarely. I added new test cases to address this, new regression data to make sure things keep working in future releases, and fields to the sandbox following the discussion in #73.