### PR TITLE
Fixing _sample_trunc_norm so that it works in both Scipy 1.4.0 and 1.5.1 (latest)

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,10 @@
 
 Changelog
 ---------
+v1.3.8
+~~~~~~
+- Fixed a bug where _sample_trunc_norm returned an array in Scipy 1.5.1, but returns a scalar in Scipy 1.4.0.
+
 v1.3.7
 ~~~~~~
 - Fixed a bug where time stretched events could have a negative start time if they were longer than the soundscape duration.

--- a/scaper/util.py
+++ b/scaper/util.py
@@ -302,8 +302,11 @@ def _sample_trunc_norm(mu, sigma, trunc_min, trunc_max, random_state):
     # values for a standard normal distribution (mu=0, sigma=1), so we need
     # to recompute a and b given the user specified parameters.
     a, b = (trunc_min - mu) / float(sigma), (trunc_max - mu) / float(sigma)
-    return scipy.stats.truncnorm.rvs(a, b, mu, sigma, random_state=random_state)
-
+    sample = scipy.stats.truncnorm.rvs(a, b, mu, sigma, random_state=random_state)
+    # scipy 1.5.1 returns an array while scipy 1.4.0 returns a scalar.
+    # To maintain backwards compat we have to cast the sample to an array 
+    # then back to a scalar.
+    return np.array(sample).item() 
 
 def max_polyphony(ann):
     '''

--- a/scaper/version.py
+++ b/scaper/version.py
@@ -3,4 +3,4 @@
 """Version info"""
 
 short_version = '1.3'
-version = '1.3.7'
+version = '1.3.8'


### PR DESCRIPTION
This follows the discussion in #107 and implements the backwards-compatible fix. Bumped version to 1.3.8.