### PR TITLE
Using Soundfile I/O operations + build_array functions from PySox

### DIFF
--- a/scaper/audio.py
+++ b/scaper/audio.py
@@ -80,7 +80,7 @@ def get_integrated_lufs(filepath, min_duration=0.5):
 
     """
     try:
-        duration = sox.file_info.duration(filepath)
+        duration = soundfile.info(filepath).duration
     except Exception as e:
         raise ScaperError(
             'Unable to obtain LUFS for {:s}, error message:\n{:s}'.format(

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -1698,204 +1698,211 @@ class Scaper(object):
 
         with _set_temp_logging_level(temp_logging_level):
 
-            # Array for storing all tmp files (one for every event)
-            tmpfiles = []
-            with _close_temp_files(tmpfiles):
-                isolated_events_audio_path = []
+            # Array for storing all generated audio (one array for every event)
+            source_audio_arrays = []
+            isolated_events_audio_path = []
+            duration_in_samples = int(self.duration * self.sr)
 
-                role_counter = {'background': 0, 'foreground': 0}
+            role_counter = {'background': 0, 'foreground': 0}
 
-                for i, e in enumerate(ann.data):
-                    if e.value['role'] == 'background':
-                        # Concatenate background if necessary. Right now we
-                        # always concatenate the background at least once,
-                        # since the pysox combiner raises an error if you try
-                        # to call build using an input_file_list with less than
-                        # 2 elements. In the future if the combiner is updated
-                        # to accept a list of length 1, then the max(..., 2)
-                        # statement can be removed from the calculation of
-                        # ntiles.
-                        source_duration = (
-                            soundfile.info(e.value['source_file']).duration)
-                        ntiles = int(
-                            max(self.duration // source_duration + 1, 2))
+            for i, e in enumerate(ann.data):
+                if e.value['role'] == 'background':
+                    # Concatenate background if necessary. Right now we
+                    # always concatenate the background at least once,
+                    # since the pysox combiner raises an error if you try
+                    # to call build using an input_file_list with less than
+                    # 2 elements. In the future if the combiner is updated
+                    # to accept a list of length 1, then the max(..., 2)
+                    # statement can be removed from the calculation of
+                    # ntiles.
+                    info = soundfile.info(e.value['source_file'])
+                    source_duration = info.duration
+                    ntiles = int(
+                        max(self.duration // source_duration + 1, 2))
 
-                        # Create combiner
-                        cmb = sox.Combiner()
-                        # Ensure consistent sampling rate and channels
-                        cmb.convert(samplerate=self.sr,
-                                    n_channels=self.n_channels,
-                                    bitdepth=None)
-                        # Then trim the duration of the background event
-                        cmb.trim(e.value['source_time'],
-                                 e.value['source_time'] +
-                                 e.value['event_duration'])
-
-                        # PROCESS BEFORE COMPUTING LUFS
-                        tmpfiles_internal = []
-                        with _close_temp_files(tmpfiles_internal):
-                            # create internal tmpfile
-                            tmpfiles_internal.append(
-                                tempfile.NamedTemporaryFile(
-                                    suffix='.wav', delete=False))
-                            # synthesize concatenated/trimmed background
-                            cmb.build(
-                                [e.value['source_file']] * ntiles,
-                                tmpfiles_internal[-1].name, 'concatenate')
-                            # NOW compute LUFS
-                            bg_lufs = get_integrated_lufs(
-                                tmpfiles_internal[-1].name)
-
-                            # Normalize background to reference DB.
-                            gain = self.ref_db - bg_lufs
-
-                            # Use transformer to adapt gain
-                            tfm = sox.Transformer()
-                            tfm.gain(gain_db=gain, normalize=False)
-
-                            # Prepare tmp file for output
-                            tmpfiles.append(
-                                tempfile.NamedTemporaryFile(
-                                    suffix='.wav', delete=False))
-
-                            tfm.build(tmpfiles_internal[-1].name,
-                                      tmpfiles[-1].name)
-
-                    elif e.value['role'] == 'foreground':
-                        # Create transformer
-                        tfm = sox.Transformer()
-                        # Ensure consistent sampling rate and channels
-                        tfm.convert(samplerate=self.sr,
-                                    n_channels=self.n_channels,
-                                    bitdepth=None)
-                        # Trim
-                        tfm.trim(e.value['source_time'],
-                                 e.value['source_time'] +
-                                 e.value['event_duration'])
-
-                        # Pitch shift
-                        if e.value['pitch_shift'] is not None:
-                            tfm.pitch(e.value['pitch_shift'])
-
-                        # Time stretch
-                        if e.value['time_stretch'] is not None:
-                            factor = 1.0 / float(e.value['time_stretch'])
-                            tfm.tempo(factor, audio_type='s', quick=False)
-
-                        # Apply very short fade in and out
-                        # (avoid unnatural sound onsets/offsets)
-                        tfm.fade(fade_in_len=self.fade_in_len,
-                                 fade_out_len=self.fade_out_len)
-
-                        # PROCESS BEFORE COMPUTING LUFS
-                        tmpfiles_internal = []
-                        with _close_temp_files(tmpfiles_internal):
-                            # create internal tmpfile
-                            tmpfiles_internal.append(
-                                tempfile.NamedTemporaryFile(
-                                    suffix='.wav', delete=False))
-                            # synthesize edited foreground sound event
-                            tfm.build(e.value['source_file'],
-                                      tmpfiles_internal[-1].name)
-                            # if time stretched get actual new duration
-                            if e.value['time_stretch'] is not None:
-                                fg_stretched_duration = soundfile.info(
-                                    tmpfiles_internal[-1].name).duration
-
-                            # NOW compute LUFS
-                            fg_lufs = get_integrated_lufs(
-                                tmpfiles_internal[-1].name)
-
-                            # Normalize to specified SNR with respect to
-                            # background
-                            tfm = sox.Transformer()
-                            gain = self.ref_db + e.value['snr'] - fg_lufs
-                            tfm.gain(gain_db=gain, normalize=False)
-
-                            # Pad with silence before/after event to match the
-                            # soundscape duration
-                            prepad = e.value['event_time']
-                            if e.value['time_stretch'] is None:
-                                postpad = max(
-                                    0, self.duration - (
-                                            e.value['event_time'] +
-                                            e.value['event_duration']))
-                            else:
-                                postpad = max(
-                                    0, self.duration - (
-                                            e.value['event_time'] +
-                                            fg_stretched_duration))
-                            tfm.pad(prepad, postpad)
-
-                            # Finally save result to a tmp file
-                            tmpfiles.append(
-                                tempfile.NamedTemporaryFile(
-                                    suffix='.wav', delete=False))
-                            tfm.build(tmpfiles_internal[-1].name,
-                                      tmpfiles[-1].name)
-                    else:
-                        raise ScaperError(
-                            'Unsupported event role: {:s}'.format(
-                                e.value['role']))
-
-                    if save_isolated_events:
-                        base, ext = os.path.splitext(audio_path)
-                        if isolated_events_path is None:
-                            event_folder = '{:s}_events'.format(base)
-                        else:
-                            event_folder = isolated_events_path
-
-                        _role_count = role_counter[e.value['role']]
-                        event_audio_path = os.path.join(
-                            event_folder, 
-                            '{:s}{:d}_{:s}{:s}'.format(
-                                e.value['role'], _role_count, e.value['label'], ext))
-                        role_counter[e.value['role']] += 1
-                        
-                        if not os.path.exists(event_folder):
-                            # In Python 3.2 and above we could do 
-                            # os.makedirs(..., exist_ok=True) but we test back to
-                            # Python 2.7.
-                            os.makedirs(event_folder)
-                        shutil.copy(tmpfiles[-1].name, event_audio_path)
-                        isolated_events_audio_path.append(event_audio_path)
-
-                        #TODO what do we do in this case? for now throw a warning
-                        if reverb is not None:
-                            warnings.warn(
-                                "Reverb is on and save_isolated_events is True. Reverberation "
-                                "is applied to the mixture but not output "
-                                "source files. In this case the sum of the "
-                                "audio of the isolated events will not add up to the "
-                                "mixture", ScaperWarning)
-
-                # Finally combine all the files and optionally apply reverb
-                # If we have more than one tempfile (i.e. background + at
-                # least one foreground event, we need a combiner. If there's
-                # only the background track, then we need a transformer!
-                if len(tmpfiles) == 0:
-                    warnings.warn(
-                        "No events to synthesize (silent soundscape), no audio "
-                        "saved to disk.", ScaperWarning)
-                elif len(tmpfiles) == 1:
+                    # Create combiner
                     tfm = sox.Transformer()
+                    # Ensure consistent sampling rate and channels
+                    tfm.convert(
+                        samplerate=self.sr,
+                        n_channels=self.n_channels,
+                        bitdepth=None
+                    )
+                    tfm.set_output_format(
+                        rate=self.sr,
+                        channels=self.n_channels
+                    )
+                    # Then trim the duration of the background event
+                    tfm.trim(e.value['source_time'],
+                                e.value['source_time'] +
+                                e.value['event_duration'])
+
+                    # PROCESS BEFORE COMPUTING LUFS
+                    tmpfiles_internal = []
+                    with _close_temp_files(tmpfiles_internal):
+                        # create internal tmpfile
+                        tmpfiles_internal.append(
+                            tempfile.NamedTemporaryFile(
+                                suffix='.wav', delete=False))
+                        # synthesize concatenated/trimmed background
+                        source_audio_array, source_rate = soundfile.read(
+                            e.value['source_file'], always_2d=True)
+                        # tile it along the appropriate dimensions
+                        source_audio_array = np.tile(source_audio_array, (ntiles, 1))
+                        output_array = tfm.build_array(
+                            input_array=source_audio_array,
+                            sample_rate_in=source_rate
+                        )
+                        # Quick hack so that LUFS computation still works
+                        soundfile.write(
+                            tmpfiles_internal[-1].name, output_array.T, self.sr)
+                        # NOW compute LUFS
+                        bg_lufs = get_integrated_lufs(
+                            tmpfiles_internal[-1].name)
+
+                        # Normalize background to reference DB.
+                        gain = self.ref_db - bg_lufs
+                        gain = self.ref_db + e.value['snr'] - bg_lufs
+                        output_array = np.exp(gain * np.log(10) / 20) * output_array
+
+                        source_audio_arrays.append(
+                            output_array[:duration_in_samples])
+
+                elif e.value['role'] == 'foreground':
+                    # Create transformer
+                    tfm = sox.Transformer()
+                    tfm.convert(
+                        samplerate=self.sr,
+                        n_channels=self.n_channels,
+                        bitdepth=None
+                    )
+                    tfm.set_output_format(
+                        rate=self.sr,
+                        channels=self.n_channels
+                    )
+                    # Trim
+                    tfm.trim(e.value['source_time'],
+                                e.value['source_time'] +
+                                e.value['event_duration'])
+
+                    # Pitch shift
+                    if e.value['pitch_shift'] is not None:
+                        tfm.pitch(e.value['pitch_shift'])
+
+                    # Time stretch
+                    if e.value['time_stretch'] is not None:
+                        factor = 1.0 / float(e.value['time_stretch'])
+                        tfm.tempo(factor, audio_type='s', quick=False)
+
+                    # Apply very short fade in and out
+                    # (avoid unnatural sound onsets/offsets)
+                    tfm.fade(fade_in_len=self.fade_in_len,
+                                fade_out_len=self.fade_out_len)
+
+                    # PROCESS BEFORE COMPUTING LUFS
+                    tmpfiles_internal = []
+                    with _close_temp_files(tmpfiles_internal):
+                        # create internal tmpfile
+                        tmpfiles_internal.append(
+                            tempfile.NamedTemporaryFile(
+                                suffix='.wav', delete=False))
+                        
+                        # synthesize edited foreground sound event
+                        source_audio_array, source_rate = soundfile.read(
+                            e.value['source_file'], always_2d=True)
+                        # tile it along the appropriate dimensions
+                        output_array = tfm.build_array(
+                            input_array=source_audio_array,
+                            sample_rate_in=source_rate
+                        )
+                        
+                        soundfile.write(
+                            tmpfiles_internal[-1].name, output_array, self.sr)
+                        # NOW compute LUFS
+                        fg_lufs = get_integrated_lufs(
+                            tmpfiles_internal[-1].name)
+
+                        # Normalize to specified SNR with respect to
+                        # background
+                        gain = self.ref_db + e.value['snr'] - fg_lufs
+                        output_array = np.exp(gain * np.log(10) / 20) * output_array
+
+                        # Pad with silence before/after event to match the
+                        # soundscape duration
+                        prepad = int(self.sr * e.value['event_time'])
+                        postpad = max(0, duration_in_samples - (output_array.shape[0] + prepad))
+                        output_array = np.pad(output_array, ((prepad, postpad)))
+                        output_array = output_array[:duration_in_samples]
+
+                        source_audio_arrays.append(
+                            output_array[:duration_in_samples])
+                else:
+                    raise ScaperError(
+                        'Unsupported event role: {:s}'.format(
+                            e.value['role']))
+
+                if save_isolated_events:
+                    base, ext = os.path.splitext(audio_path)
+                    if isolated_events_path is None:
+                        event_folder = '{:s}_events'.format(base)
+                    else:
+                        event_folder = isolated_events_path
+
+                    _role_count = role_counter[e.value['role']]
+                    event_audio_path = os.path.join(
+                        event_folder, 
+                        '{:s}{:d}_{:s}{:s}'.format(
+                            e.value['role'], _role_count, e.value['label'], ext))
+                    role_counter[e.value['role']] += 1
+                    
+                    if not os.path.exists(event_folder):
+                        # In Python 3.2 and above we could do 
+                        # os.makedirs(..., exist_ok=True) but we test back to
+                        # Python 2.7.
+                        os.makedirs(event_folder)
+                    soundfile.write(event_audio_path, source_audio_arrays[-1], self.sr)
+                    isolated_events_audio_path.append(event_audio_path)
+
+                    #TODO what do we do in this case? for now throw a warning
                     if reverb is not None:
-                        tfm.reverb(reverberance=reverb * 100)
-                    # TODO: do we want to normalize the final output?
-                    tfm.build(tmpfiles[0].name, audio_path)
-                else:                        
-                    cmb = sox.Combiner()
-                    if reverb is not None:
-                        cmb.reverb(reverberance=reverb * 100)
-                    # TODO: do we want to normalize the final output?
-                    cmb.build([t.name for t in tmpfiles], audio_path, 'mix')
-                
-                # Make sure every single audio file has exactly the same duration 
-                # using soundfile.
-                duration_in_samples = int(self.duration * self.sr)
-                for _audio_file in [audio_path] + isolated_events_audio_path:
-                    match_sample_length(_audio_file, duration_in_samples)
-        
+                        warnings.warn(
+                            "Reverb is on and save_isolated_events is True. Reverberation "
+                            "is applied to the mixture but not output "
+                            "source files. In this case the sum of the "
+                            "audio of the isolated events will not add up to the "
+                            "mixture", ScaperWarning)
+
+            # Finally combine all the files and optionally apply reverb
+            # If we have more than one tempfile (i.e. background + at
+            # least one foreground event, we need a combiner. If there's
+            # only the background track, then we need a transformer!
+            if len(source_audio_arrays) == 0:
+                warnings.warn(
+                    "No events to synthesize (silent soundscape), no audio "
+                    "saved to disk.", ScaperWarning)
+            elif len(source_audio_arrays) == 1:
+                tfm = sox.Transformer()
+                if reverb is not None:
+                    tfm.reverb(reverberance=reverb * 100)
+                # TODO: do we want to normalize the final output?
+                output_array = tfm.build_array(
+                    input_array=source_audio_arrays[0], 
+                    sample_rate_in=self.sr,
+                )
+                soundfile.write(audio_path, output_array, self.sr)
+            else:                        
+                tfm = sox.Transformer()
+                if reverb is not None:
+                    tfm.reverb(reverberance=reverb * 100)
+                # TODO: do we want to normalize the final output?
+
+                soundscape_audio = sum(source_audio_arrays)
+                output_array = tfm.build_array(
+                    input_array=soundscape_audio,
+                    sample_rate_in=self.sr,
+                )
+                soundfile.write(audio_path, output_array, self.sr)
+                        
         ann.sandbox.scaper.soundscape_audio_path = audio_path
         ann.sandbox.scaper.isolated_events_audio_path = isolated_events_audio_path
 

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -1831,7 +1831,7 @@ class Scaper(object):
                         # soundscape duration
                         prepad = int(self.sr * e.value['event_time'])
                         postpad = max(0, duration_in_samples - (output_array.shape[0] + prepad))
-                        output_array = np.pad(output_array, ((prepad, postpad)))
+                        output_array = np.pad(output_array, ((prepad, postpad)), mode='constant')
                         output_array = output_array[:duration_in_samples]
 
                         source_audio_arrays.append(

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -1705,190 +1705,186 @@ class Scaper(object):
 
             role_counter = {'background': 0, 'foreground': 0}
 
-            # TODO: This is for a cleaner diff, remove it after CR.
-            tmpfiles = []
-            with _close_temp_files(tmpfiles):
-                for i, e in enumerate(ann.data):
-                    if e.value['role'] == 'background':
-                        # Concatenate background if necessary.
-                        source_duration = soundfile.info(e.value['source_file']).duration
-                        ntiles = int(
-                            max(self.duration // source_duration + 1, 1))
+            for i, e in enumerate(ann.data):
+                if e.value['role'] == 'background':
+                    # Concatenate background if necessary.
+                    source_duration = soundfile.info(e.value['source_file']).duration
+                    ntiles = int(
+                        max(self.duration // source_duration + 1, 1))
 
-                        # Create transformer
-                        tfm = sox.Transformer()
-                        # Ensure consistent sampling rate and channels
-                        # Need both a convert operation (to do the conversion),
-                        # and set_output_format (to have sox interpret the output
-                        # correctly).
-                        tfm.convert(
-                            samplerate=self.sr,
-                            n_channels=self.n_channels,
-                            bitdepth=None
-                        )
-                        tfm.set_output_format(
-                            rate=self.sr,
-                            channels=self.n_channels
-                        )
-                        # Then trim the duration of the background event
-                        tfm.trim(e.value['source_time'],
-                                 e.value['source_time'] +
-                                 e.value['event_duration'])
-
-                        # PROCESS BEFORE COMPUTING LUFS
-                        tmpfiles_internal = []
-                        with _close_temp_files(tmpfiles_internal):
-                            # create internal tmpfile
-                            tmpfiles_internal.append(
-                                tempfile.NamedTemporaryFile(
-                                    suffix='.wav', delete=False))
-                            # read in background off disk
-                            event_audio, event_sr = soundfile.read(
-                                e.value['source_file'], always_2d=True)
-                            # tile the background along the appropriate dimensions
-                            event_audio = np.tile(event_audio, (ntiles, 1))
-                            event_audio = tfm.build_array(
-                                input_array=event_audio,
-                                sample_rate_in=event_sr
-                            )
-                            # Write event_audio_array to disk so we can compute LUFS using ffmpeg
-                            soundfile.write(
-                                tmpfiles_internal[-1].name, event_audio.T, self.sr)
-                            # NOW compute LUFS
-                            bg_lufs = get_integrated_lufs(
-                                tmpfiles_internal[-1].name)
-
-                            # Normalize background to reference DB.
-                            gain = self.ref_db - bg_lufs
-                            event_audio = np.exp(gain * np.log(10) / 20) * event_audio
-
-                            event_audio_list.append(
-                                event_audio[:duration_in_samples])
-
-                    elif e.value['role'] == 'foreground':
-                        # Create transformer
-                        tfm = sox.Transformer()
-                        # Ensure consistent sampling rate and channels
-                        # Need both a convert operation (to do the conversion),
-                        # and set_output_format (to have sox interpret the output
-                        # correctly).
-                        tfm.convert(
-                            samplerate=self.sr,
-                            n_channels=self.n_channels,
-                            bitdepth=None
-                        )
-                        tfm.set_output_format(
-                            rate=self.sr,
-                            channels=self.n_channels
-                        )
-                        # Trim
-                        tfm.trim(e.value['source_time'],
-                                 e.value['source_time'] +
-                                 e.value['event_duration'])
-
-                        # Pitch shift
-                        if e.value['pitch_shift'] is not None:
-                            tfm.pitch(e.value['pitch_shift'])
-
-                        # Time stretch
-                        if e.value['time_stretch'] is not None:
-                            factor = 1.0 / float(e.value['time_stretch'])
-                            tfm.tempo(factor, audio_type='s', quick=False)
-
-                        # Apply very short fade in and out
-                        # (avoid unnatural sound onsets/offsets)
-                        tfm.fade(fade_in_len=self.fade_in_len,
-                                 fade_out_len=self.fade_out_len)
-
-                        # PROCESS BEFORE COMPUTING LUFS
-                        tmpfiles_internal = []
-                        with _close_temp_files(tmpfiles_internal):
-                            # create internal tmpfile
-                            tmpfiles_internal.append(
-                                tempfile.NamedTemporaryFile(
-                                    suffix='.wav', delete=False))
-                            
-                            # synthesize edited foreground sound event
-                            event_audio, event_sr = soundfile.read(
-                                e.value['source_file'], always_2d=True)
-                            event_audio = tfm.build_array(
-                                input_array=event_audio,
-                                sample_rate_in=event_sr
-                            )
-                            soundfile.write(
-                                tmpfiles_internal[-1].name, event_audio.T, self.sr)
-                            # NOW compute LUFS
-                            fg_lufs = get_integrated_lufs(
-                                tmpfiles_internal[-1].name)
-
-                            # Normalize to specified SNR with respect to
-                            # background
-                            gain = self.ref_db + e.value['snr'] - fg_lufs
-                            event_audio = np.exp(gain * np.log(10) / 20) * event_audio
-
-                            # Pad with silence before/after event to match the
-                            # soundscape duration
-                            prepad = int(self.sr * e.value['event_time'])
-                            postpad = max(0, duration_in_samples - (event_audio.shape[0] + prepad))
-                            event_audio = np.pad(event_audio, ((prepad, postpad)), mode='constant',
-                                constant_values=(0, 0))
-                            event_audio = event_audio[:duration_in_samples]
-
-                            event_audio_list.append(event_audio[:duration_in_samples])
-                    else:
-                        raise ScaperError(
-                            'Unsupported event role: {:s}'.format(
-                                e.value['role']))
-
-                    if save_isolated_events:
-                        base, ext = os.path.splitext(audio_path)
-                        if isolated_events_path is None:
-                            event_folder = '{:s}_events'.format(base)
-                        else:
-                            event_folder = isolated_events_path
-
-                        _role_count = role_counter[e.value['role']]
-                        event_audio_path = os.path.join(
-                            event_folder, 
-                            '{:s}{:d}_{:s}{:s}'.format(
-                                e.value['role'], _role_count, e.value['label'], ext))
-                        role_counter[e.value['role']] += 1
-                        
-                        if not os.path.exists(event_folder):
-                            # In Python 3.2 and above we could do 
-                            # os.makedirs(..., exist_ok=True) but we test back to
-                            # Python 2.7.
-                            os.makedirs(event_folder)
-                        soundfile.write(event_audio_path, event_audio_list[-1].T, self.sr)
-                        isolated_events_audio_path.append(event_audio_path)
-
-                        #TODO what do we do in this case? for now throw a warning
-                        if reverb is not None:
-                            warnings.warn(
-                                "Reverb is on and save_isolated_events is True. Reverberation "
-                                "is applied to the mixture but not output "
-                                "source files. In this case the sum of the "
-                                "audio of the isolated events will not add up to the "
-                                "mixture", ScaperWarning)
-
-                # Finally combine all the files and optionally apply reverb.
-                # If there are no events, throw a warning.
-                if len(event_audio_list) == 0:
-                    warnings.warn(
-                        "No events to synthesize (silent soundscape), no audio "
-                        "saved to disk.", ScaperWarning)
-                else:                        
+                    # Create transformer
                     tfm = sox.Transformer()
-                    if reverb is not None:
-                        tfm.reverb(reverberance=reverb * 100)
-                    # TODO: do we want to normalize the final output?
-
-                    soundscape_audio = sum(event_audio_list)
-                    soundscape_audio = tfm.build_array(
-                        input_array=soundscape_audio,
-                        sample_rate_in=self.sr,
+                    # Ensure consistent sampling rate and channels
+                    # Need both a convert operation (to do the conversion),
+                    # and set_output_format (to have sox interpret the output
+                    # correctly).
+                    tfm.convert(
+                        samplerate=self.sr,
+                        n_channels=self.n_channels,
+                        bitdepth=None
                     )
-                    soundfile.write(audio_path, soundscape_audio, self.sr)
+                    tfm.set_output_format(
+                        rate=self.sr,
+                        channels=self.n_channels
+                    )
+                    # Then trim the duration of the background event
+                    tfm.trim(e.value['source_time'],
+                                e.value['source_time'] +
+                                e.value['event_duration'])
+
+                    # PROCESS BEFORE COMPUTING LUFS
+                    tmpfiles_internal = []
+                    with _close_temp_files(tmpfiles_internal):
+                        # create internal tmpfile
+                        tmpfiles_internal.append(
+                            tempfile.NamedTemporaryFile(
+                                suffix='.wav', delete=False))
+                        # read in background off disk
+                        event_audio, event_sr = soundfile.read(
+                            e.value['source_file'], always_2d=True)
+                        # tile the background along the appropriate dimensions
+                        event_audio = np.tile(event_audio, (ntiles, 1))
+                        event_audio = tfm.build_array(
+                            input_array=event_audio,
+                            sample_rate_in=event_sr
+                        )
+                        # Write event_audio_array to disk so we can compute LUFS using ffmpeg
+                        soundfile.write(
+                            tmpfiles_internal[-1].name, event_audio.T, self.sr)
+                        # NOW compute LUFS
+                        bg_lufs = get_integrated_lufs(
+                            tmpfiles_internal[-1].name)
+
+                        # Normalize background to reference DB.
+                        gain = self.ref_db - bg_lufs
+                        event_audio = np.exp(gain * np.log(10) / 20) * event_audio
+
+                        event_audio_list.append(event_audio[:duration_in_samples])
+
+                elif e.value['role'] == 'foreground':
+                    # Create transformer
+                    tfm = sox.Transformer()
+                    # Ensure consistent sampling rate and channels
+                    # Need both a convert operation (to do the conversion),
+                    # and set_output_format (to have sox interpret the output
+                    # correctly).
+                    tfm.convert(
+                        samplerate=self.sr,
+                        n_channels=self.n_channels,
+                        bitdepth=None
+                    )
+                    tfm.set_output_format(
+                        rate=self.sr,
+                        channels=self.n_channels
+                    )
+                    # Trim
+                    tfm.trim(e.value['source_time'],
+                                e.value['source_time'] +
+                                e.value['event_duration'])
+
+                    # Pitch shift
+                    if e.value['pitch_shift'] is not None:
+                        tfm.pitch(e.value['pitch_shift'])
+
+                    # Time stretch
+                    if e.value['time_stretch'] is not None:
+                        factor = 1.0 / float(e.value['time_stretch'])
+                        tfm.tempo(factor, audio_type='s', quick=False)
+
+                    # Apply very short fade in and out
+                    # (avoid unnatural sound onsets/offsets)
+                    tfm.fade(fade_in_len=self.fade_in_len,
+                                fade_out_len=self.fade_out_len)
+
+                    # PROCESS BEFORE COMPUTING LUFS
+                    tmpfiles_internal = []
+                    with _close_temp_files(tmpfiles_internal):
+                        # create internal tmpfile
+                        tmpfiles_internal.append(
+                            tempfile.NamedTemporaryFile(
+                                suffix='.wav', delete=False))
+                        
+                        # synthesize edited foreground sound event
+                        event_audio, event_sr = soundfile.read(
+                            e.value['source_file'], always_2d=True)
+                        event_audio = tfm.build_array(
+                            input_array=event_audio,
+                            sample_rate_in=event_sr
+                        )
+                        soundfile.write(
+                            tmpfiles_internal[-1].name, event_audio.T, self.sr)
+                        # NOW compute LUFS
+                        fg_lufs = get_integrated_lufs(
+                            tmpfiles_internal[-1].name)
+
+                        # Normalize to specified SNR with respect to
+                        # background
+                        gain = self.ref_db + e.value['snr'] - fg_lufs
+                        event_audio = np.exp(gain * np.log(10) / 20) * event_audio
+
+                        # Pad with silence before/after event to match the
+                        # soundscape duration
+                        prepad = int(self.sr * e.value['event_time'])
+                        postpad = max(0, duration_in_samples - (event_audio.shape[0] + prepad))
+                        event_audio = np.pad(event_audio, ((prepad, postpad)), mode='constant',
+                            constant_values=(0, 0))
+                        event_audio = event_audio[:duration_in_samples]
+
+                        event_audio_list.append(event_audio[:duration_in_samples])
+                else:
+                    raise ScaperError(
+                        'Unsupported event role: {:s}'.format(
+                            e.value['role']))
+
+                if save_isolated_events:
+                    base, ext = os.path.splitext(audio_path)
+                    if isolated_events_path is None:
+                        event_folder = '{:s}_events'.format(base)
+                    else:
+                        event_folder = isolated_events_path
+
+                    _role_count = role_counter[e.value['role']]
+                    event_audio_path = os.path.join(
+                        event_folder, 
+                        '{:s}{:d}_{:s}{:s}'.format(
+                            e.value['role'], _role_count, e.value['label'], ext))
+                    role_counter[e.value['role']] += 1
+                    
+                    if not os.path.exists(event_folder):
+                        # In Python 3.2 and above we could do 
+                        # os.makedirs(..., exist_ok=True) but we test back to
+                        # Python 2.7.
+                        os.makedirs(event_folder)
+                    soundfile.write(event_audio_path, event_audio_list[-1].T, self.sr)
+                    isolated_events_audio_path.append(event_audio_path)
+
+                    #TODO what do we do in this case? for now throw a warning
+                    if reverb is not None:
+                        warnings.warn(
+                            "Reverb is on and save_isolated_events is True. Reverberation "
+                            "is applied to the mixture but not output "
+                            "source files. In this case the sum of the "
+                            "audio of the isolated events will not add up to the "
+                            "mixture", ScaperWarning)
+
+            # Finally combine all the files and optionally apply reverb.
+            # If there are no events, throw a warning.
+            if len(event_audio_list) == 0:
+                warnings.warn(
+                    "No events to synthesize (silent soundscape), no audio "
+                    "saved to disk.", ScaperWarning)
+            else:                        
+                tfm = sox.Transformer()
+                if reverb is not None:
+                    tfm.reverb(reverberance=reverb * 100)
+                # TODO: do we want to normalize the final output?
+
+                soundscape_audio = sum(event_audio_list)
+                soundscape_audio = tfm.build_array(
+                    input_array=soundscape_audio,
+                    sample_rate_in=self.sr,
+                )
+                soundfile.write(audio_path, soundscape_audio, self.sr)
                         
         ann.sandbox.scaper.soundscape_audio_path = audio_path
         ann.sandbox.scaper.isolated_events_audio_path = isolated_events_audio_path

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -1705,188 +1705,191 @@ class Scaper(object):
 
             role_counter = {'background': 0, 'foreground': 0}
 
-            for i, e in enumerate(ann.data):
-                if e.value['role'] == 'background':
-                    # Concatenate background if necessary.
-                    source_duration = soundfile.info(e.value['source_file']).duration
-                    ntiles = int(
-                        max(self.duration // source_duration + 1, 1))
+            # TODO: This is for a cleaner diff, remove it after CR.
+            tmpfiles = []
+            with _close_temp_files(tmpfiles):
+                for i, e in enumerate(ann.data):
+                    if e.value['role'] == 'background':
+                        # Concatenate background if necessary.
+                        source_duration = soundfile.info(e.value['source_file']).duration
+                        ntiles = int(
+                            max(self.duration // source_duration + 1, 1))
 
-                    # Create transformer
-                    tfm = sox.Transformer()
-                    # Ensure consistent sampling rate and channels
-                    # Need both a convert operation (to do the conversion),
-                    # and set_output_format (to have sox interpret the output
-                    # correctly).
-                    tfm.convert(
-                        samplerate=self.sr,
-                        n_channels=self.n_channels,
-                        bitdepth=None
-                    )
-                    tfm.set_output_format(
-                        rate=self.sr,
-                        channels=self.n_channels
-                    )
-                    # Then trim the duration of the background event
-                    tfm.trim(e.value['source_time'],
-                                e.value['source_time'] +
-                                e.value['event_duration'])
-
-                    # PROCESS BEFORE COMPUTING LUFS
-                    tmpfiles_internal = []
-                    with _close_temp_files(tmpfiles_internal):
-                        # create internal tmpfile
-                        tmpfiles_internal.append(
-                            tempfile.NamedTemporaryFile(
-                                suffix='.wav', delete=False))
-                        # read in background off disk
-                        event_audio_array, event_sample_rate = soundfile.read(
-                            e.value['source_file'], always_2d=True)
-                        # tile the background along the appropriate dimensions
-                        event_audio_array = np.tile(event_audio_array, (ntiles, 1))
-                        event_audio_array = tfm.build_array(
-                            input_array=event_audio_array,
-                            sample_rate_in=event_sample_rate
+                        # Create transformer
+                        tfm = sox.Transformer()
+                        # Ensure consistent sampling rate and channels
+                        # Need both a convert operation (to do the conversion),
+                        # and set_output_format (to have sox interpret the output
+                        # correctly).
+                        tfm.convert(
+                            samplerate=self.sr,
+                            n_channels=self.n_channels,
+                            bitdepth=None
                         )
-                        # Write event_audio_array to disk so we can compute LUFS using ffmpeg
-                        soundfile.write(
-                            tmpfiles_internal[-1].name, event_audio_array.T, self.sr)
-                        # NOW compute LUFS
-                        bg_lufs = get_integrated_lufs(
-                            tmpfiles_internal[-1].name)
-
-                        # Normalize background to reference DB.
-                        gain = self.ref_db - bg_lufs
-                        gain = self.ref_db + e.value['snr'] - bg_lufs
-                        event_audio_array = np.exp(gain * np.log(10) / 20) * event_audio_array
-
-                        event_audio_arrays.append(
-                            event_audio_array[:duration_in_samples])
-
-                elif e.value['role'] == 'foreground':
-                    # Create transformer
-                    tfm = sox.Transformer()
-                    # Ensure consistent sampling rate and channels
-                    # Need both a convert operation (to do the conversion),
-                    # and set_output_format (to have sox interpret the output
-                    # correctly).
-                    tfm.convert(
-                        samplerate=self.sr,
-                        n_channels=self.n_channels,
-                        bitdepth=None
-                    )
-                    tfm.set_output_format(
-                        rate=self.sr,
-                        channels=self.n_channels
-                    )
-                    # Trim
-                    tfm.trim(e.value['source_time'],
-                                e.value['source_time'] +
-                                e.value['event_duration'])
-
-                    # Pitch shift
-                    if e.value['pitch_shift'] is not None:
-                        tfm.pitch(e.value['pitch_shift'])
-
-                    # Time stretch
-                    if e.value['time_stretch'] is not None:
-                        factor = 1.0 / float(e.value['time_stretch'])
-                        tfm.tempo(factor, audio_type='s', quick=False)
-
-                    # Apply very short fade in and out
-                    # (avoid unnatural sound onsets/offsets)
-                    tfm.fade(fade_in_len=self.fade_in_len,
-                                fade_out_len=self.fade_out_len)
-
-                    # PROCESS BEFORE COMPUTING LUFS
-                    tmpfiles_internal = []
-                    with _close_temp_files(tmpfiles_internal):
-                        # create internal tmpfile
-                        tmpfiles_internal.append(
-                            tempfile.NamedTemporaryFile(
-                                suffix='.wav', delete=False))
-                        
-                        # synthesize edited foreground sound event
-                        event_audio_array, event_audio_rate = soundfile.read(
-                            e.value['source_file'], always_2d=True)
-                        event_audio_array = tfm.build_array(
-                            input_array=event_audio_array,
-                            sample_rate_in=event_audio_rate
+                        tfm.set_output_format(
+                            rate=self.sr,
+                            channels=self.n_channels
                         )
-                        soundfile.write(
-                            tmpfiles_internal[-1].name, event_audio_array.T, self.sr)
-                        # NOW compute LUFS
-                        fg_lufs = get_integrated_lufs(
-                            tmpfiles_internal[-1].name)
+                        # Then trim the duration of the background event
+                        tfm.trim(e.value['source_time'],
+                                    e.value['source_time'] +
+                                    e.value['event_duration'])
 
-                        # Normalize to specified SNR with respect to
-                        # background
-                        gain = self.ref_db + e.value['snr'] - fg_lufs
-                        event_audio_array = np.exp(gain * np.log(10) / 20) * event_audio_array
+                        # PROCESS BEFORE COMPUTING LUFS
+                        tmpfiles_internal = []
+                        with _close_temp_files(tmpfiles_internal):
+                            # create internal tmpfile
+                            tmpfiles_internal.append(
+                                tempfile.NamedTemporaryFile(
+                                    suffix='.wav', delete=False))
+                            # read in background off disk
+                            event_audio_array, event_sample_rate = soundfile.read(
+                                e.value['source_file'], always_2d=True)
+                            # tile the background along the appropriate dimensions
+                            event_audio_array = np.tile(event_audio_array, (ntiles, 1))
+                            event_audio_array = tfm.build_array(
+                                input_array=event_audio_array,
+                                sample_rate_in=event_sample_rate
+                            )
+                            # Write event_audio_array to disk so we can compute LUFS using ffmpeg
+                            soundfile.write(
+                                tmpfiles_internal[-1].name, event_audio_array.T, self.sr)
+                            # NOW compute LUFS
+                            bg_lufs = get_integrated_lufs(
+                                tmpfiles_internal[-1].name)
 
-                        # Pad with silence before/after event to match the
-                        # soundscape duration
-                        prepad = int(self.sr * e.value['event_time'])
-                        postpad = max(0, duration_in_samples - (event_audio_array.shape[0] + prepad))
-                        event_audio_array = np.pad(event_audio_array, ((prepad, postpad)), mode='constant')
-                        event_audio_array = event_audio_array[:duration_in_samples]
+                            # Normalize background to reference DB.
+                            gain = self.ref_db - bg_lufs
+                            gain = self.ref_db + e.value['snr'] - bg_lufs
+                            event_audio_array = np.exp(gain * np.log(10) / 20) * event_audio_array
 
-                        event_audio_arrays.append(
-                            event_audio_array[:duration_in_samples])
-                else:
-                    raise ScaperError(
-                        'Unsupported event role: {:s}'.format(
-                            e.value['role']))
+                            event_audio_arrays.append(
+                                event_audio_array[:duration_in_samples])
 
-                if save_isolated_events:
-                    base, ext = os.path.splitext(audio_path)
-                    if isolated_events_path is None:
-                        event_folder = '{:s}_events'.format(base)
+                    elif e.value['role'] == 'foreground':
+                        # Create transformer
+                        tfm = sox.Transformer()
+                        # Ensure consistent sampling rate and channels
+                        # Need both a convert operation (to do the conversion),
+                        # and set_output_format (to have sox interpret the output
+                        # correctly).
+                        tfm.convert(
+                            samplerate=self.sr,
+                            n_channels=self.n_channels,
+                            bitdepth=None
+                        )
+                        tfm.set_output_format(
+                            rate=self.sr,
+                            channels=self.n_channels
+                        )
+                        # Trim
+                        tfm.trim(e.value['source_time'],
+                                    e.value['source_time'] +
+                                    e.value['event_duration'])
+
+                        # Pitch shift
+                        if e.value['pitch_shift'] is not None:
+                            tfm.pitch(e.value['pitch_shift'])
+
+                        # Time stretch
+                        if e.value['time_stretch'] is not None:
+                            factor = 1.0 / float(e.value['time_stretch'])
+                            tfm.tempo(factor, audio_type='s', quick=False)
+
+                        # Apply very short fade in and out
+                        # (avoid unnatural sound onsets/offsets)
+                        tfm.fade(fade_in_len=self.fade_in_len,
+                                    fade_out_len=self.fade_out_len)
+
+                        # PROCESS BEFORE COMPUTING LUFS
+                        tmpfiles_internal = []
+                        with _close_temp_files(tmpfiles_internal):
+                            # create internal tmpfile
+                            tmpfiles_internal.append(
+                                tempfile.NamedTemporaryFile(
+                                    suffix='.wav', delete=False))
+                            
+                            # synthesize edited foreground sound event
+                            event_audio_array, event_audio_rate = soundfile.read(
+                                e.value['source_file'], always_2d=True)
+                            event_audio_array = tfm.build_array(
+                                input_array=event_audio_array,
+                                sample_rate_in=event_audio_rate
+                            )
+                            soundfile.write(
+                                tmpfiles_internal[-1].name, event_audio_array.T, self.sr)
+                            # NOW compute LUFS
+                            fg_lufs = get_integrated_lufs(
+                                tmpfiles_internal[-1].name)
+
+                            # Normalize to specified SNR with respect to
+                            # background
+                            gain = self.ref_db + e.value['snr'] - fg_lufs
+                            event_audio_array = np.exp(gain * np.log(10) / 20) * event_audio_array
+
+                            # Pad with silence before/after event to match the
+                            # soundscape duration
+                            prepad = int(self.sr * e.value['event_time'])
+                            postpad = max(0, duration_in_samples - (event_audio_array.shape[0] + prepad))
+                            event_audio_array = np.pad(event_audio_array, ((prepad, postpad)), mode='constant')
+                            event_audio_array = event_audio_array[:duration_in_samples]
+
+                            event_audio_arrays.append(
+                                event_audio_array[:duration_in_samples])
                     else:
-                        event_folder = isolated_events_path
+                        raise ScaperError(
+                            'Unsupported event role: {:s}'.format(
+                                e.value['role']))
 
-                    _role_count = role_counter[e.value['role']]
-                    event_audio_path = os.path.join(
-                        event_folder, 
-                        '{:s}{:d}_{:s}{:s}'.format(
-                            e.value['role'], _role_count, e.value['label'], ext))
-                    role_counter[e.value['role']] += 1
-                    
-                    if not os.path.exists(event_folder):
-                        # In Python 3.2 and above we could do 
-                        # os.makedirs(..., exist_ok=True) but we test back to
-                        # Python 2.7.
-                        os.makedirs(event_folder)
-                    soundfile.write(event_audio_path, event_audio_arrays[-1].T, self.sr)
-                    isolated_events_audio_path.append(event_audio_path)
+                    if save_isolated_events:
+                        base, ext = os.path.splitext(audio_path)
+                        if isolated_events_path is None:
+                            event_folder = '{:s}_events'.format(base)
+                        else:
+                            event_folder = isolated_events_path
 
-                    #TODO what do we do in this case? for now throw a warning
+                        _role_count = role_counter[e.value['role']]
+                        event_audio_path = os.path.join(
+                            event_folder, 
+                            '{:s}{:d}_{:s}{:s}'.format(
+                                e.value['role'], _role_count, e.value['label'], ext))
+                        role_counter[e.value['role']] += 1
+                        
+                        if not os.path.exists(event_folder):
+                            # In Python 3.2 and above we could do 
+                            # os.makedirs(..., exist_ok=True) but we test back to
+                            # Python 2.7.
+                            os.makedirs(event_folder)
+                        soundfile.write(event_audio_path, event_audio_arrays[-1].T, self.sr)
+                        isolated_events_audio_path.append(event_audio_path)
+
+                        #TODO what do we do in this case? for now throw a warning
+                        if reverb is not None:
+                            warnings.warn(
+                                "Reverb is on and save_isolated_events is True. Reverberation "
+                                "is applied to the mixture but not output "
+                                "source files. In this case the sum of the "
+                                "audio of the isolated events will not add up to the "
+                                "mixture", ScaperWarning)
+
+                # Finally combine all the files and optionally apply reverb.
+                # If there are no events, throw a warning.
+                if len(event_audio_arrays) == 0:
+                    warnings.warn(
+                        "No events to synthesize (silent soundscape), no audio "
+                        "saved to disk.", ScaperWarning)
+                else:                        
+                    tfm = sox.Transformer()
                     if reverb is not None:
-                        warnings.warn(
-                            "Reverb is on and save_isolated_events is True. Reverberation "
-                            "is applied to the mixture but not output "
-                            "source files. In this case the sum of the "
-                            "audio of the isolated events will not add up to the "
-                            "mixture", ScaperWarning)
+                        tfm.reverb(reverberance=reverb * 100)
+                    # TODO: do we want to normalize the final output?
 
-            # Finally combine all the files and optionally apply reverb.
-            # If there are no events, throw a warning.
-            if len(event_audio_arrays) == 0:
-                warnings.warn(
-                    "No events to synthesize (silent soundscape), no audio "
-                    "saved to disk.", ScaperWarning)
-            else:                        
-                tfm = sox.Transformer()
-                if reverb is not None:
-                    tfm.reverb(reverberance=reverb * 100)
-                # TODO: do we want to normalize the final output?
-
-                soundscape_audio = sum(event_audio_arrays)
-                soundscape_audio = tfm.build_array(
-                    input_array=soundscape_audio,
-                    sample_rate_in=self.sr,
-                )
-                soundfile.write(audio_path, soundscape_audio, self.sr)
+                    soundscape_audio = sum(event_audio_arrays)
+                    soundscape_audio = tfm.build_array(
+                        input_array=soundscape_audio,
+                        sample_rate_in=self.sr,
+                    )
+                    soundfile.write(audio_path, soundscape_audio, self.sr)
                         
         ann.sandbox.scaper.soundscape_audio_path = audio_path
         ann.sandbox.scaper.isolated_events_audio_path = isolated_events_audio_path

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -1715,6 +1715,9 @@ class Scaper(object):
                     # Create transformer
                     tfm = sox.Transformer()
                     # Ensure consistent sampling rate and channels
+                    # Need both a convert operation (to do the conversion),
+                    # and set_output_format (to have sox interpret the output
+                    # correctly).
                     tfm.convert(
                         samplerate=self.sr,
                         n_channels=self.n_channels,
@@ -1763,6 +1766,10 @@ class Scaper(object):
                 elif e.value['role'] == 'foreground':
                     # Create transformer
                     tfm = sox.Transformer()
+                    # Ensure consistent sampling rate and channels
+                    # Need both a convert operation (to do the conversion),
+                    # and set_output_format (to have sox interpret the output
+                    # correctly).
                     tfm.convert(
                         samplerate=self.sr,
                         n_channels=self.n_channels,

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -1802,7 +1802,6 @@ class Scaper(object):
                         # synthesize edited foreground sound event
                         event_audio_array, event_audio_rate = soundfile.read(
                             e.value['source_file'], always_2d=True)
-                        # tile it along the appropriate dimensions
                         event_audio_array = tfm.build_array(
                             input_array=event_audio_array,
                             sample_rate_in=event_audio_rate

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -1760,7 +1760,6 @@ class Scaper(object):
 
                             # Normalize background to reference DB.
                             gain = self.ref_db - bg_lufs
-                            gain = self.ref_db - bg_lufs
                             event_audio = np.exp(gain * np.log(10) / 20) * event_audio
 
                             event_audio_list.append(

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
             "Programming Language :: Python :: 3.6",
         ],
     install_requires=[
-        'sox>=1.3.3',
+        'sox==1.4.0b0',
         'jams>=0.3.2',
         'numpy>=1.13.3',
         'soundfile'

--- a/tests/profile_results.csv
+++ b/tests/profile_results.csv
@@ -1,3 +1,4 @@
 time_of_run,scaper_version,python_version,system,machine,processor,n_cpu,n_workers,memory,n_soundscapes,execution_time,git_commit_hash
 2020-07-17 14:13:46.982171,1.3.8,3.7.7,Darwin,x86_64,i386,8,1,16.0 GB,100,149.7468,e0c08d4f6eb10bc0b337a9d47f86b3b110ed0836
 2020-07-17 14:59:33.707885,1.3.8,3.7.7,Darwin,x86_64,i386,8,1,16.0 GB,100,135.1724,c780d270b0ea0c691e1cc1dbf725d1c4b35e5299
+2020-07-20 14:39:41.950552,1.3.8,3.7.7,Darwin,x86_64,i386,8,1,16.0 GB,100,118.7033,8c0cfe3c14e06bf46bcd6480f6be5991b0fba077


### PR DESCRIPTION
This PR achieves more milestones from #105. It does the following:

> - The current pysox master now can accept and return numpy arrays when doing tfm.build. By updating to this, we will be able to do everything in-memory, but will still have exec calls.
> - Once we use soundfile to load the audio files, we can get rid of sox.Combiner and should do all the summing of mixtures in-memory.

Gain adjustments of background and foreground events all use in-memory operations on the numpy arrays, which matches the gain adjustments made within sox (the code matches sox source code).

What Scaper does now:

```python
gain = self.ref_db + e.value['snr'] - fg_lufs
output_array = np.exp(gain * np.log(10) / 20) * output_array
```

What sox does under the hood:

```c
#ifndef M_LN10
#define M_LN10  2.30258509299404568402  /* natural log of 10 */
#endif

#define dB_to_linear(x) exp((x) * M_LN10 * 0.05)
```