### PR TITLE
Fix for Issue #113, trimming with isolated events.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,10 @@
 
 Changelog
 ---------
+v1.3.9
+~~~~~~
+- Fixed a bug where trim before generating soundscapes from a JAMS file with saving of isolated events resulted in incorrect soundscape audio.
+
 v1.3.8
 ~~~~~~
 - Fixed a bug where _sample_trunc_norm returned an array in Scipy 1.5.1, but returns a scalar in Scipy 1.4.0.

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -193,7 +193,7 @@ def generate_from_jams(jams_infile, audio_outfile, fg_path=None, bg_path=None,
                     tfm.trim(sliceop['slice_start'], sliceop['slice_end'])
                     tfm.build(audio_file, tmpfiles[-1].name)
                     # Copy result back to original file
-                    shutil.copyfile(tmpfiles[-1].name, audio_outfile)
+                    shutil.copyfile(tmpfiles[-1].name, audio_file)
 
     # Optionally save new jams file
     if jams_outfile is not None:

--- a/scaper/version.py
+++ b/scaper/version.py
@@ -3,4 +3,4 @@
 """Version info"""
 
 short_version = '1.3'
-version = '1.3.8'
+version = '1.3.9'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -229,7 +229,7 @@ def test_generate_from_jams(atol=1e-5, rtol=1e-8):
 
         # Now add in trimming!
         for _ in range(5):
-            with tempfile.TemporaryDirectory() as gen_events_path:
+            with backports.tempfile.TemporaryDirectory() as gen_events_path:
                 sc.generate(orig_wav_file.name, orig_jam_file.name,
                             disable_instantiation_warnings=True,
                             save_isolated_events=True)
@@ -245,7 +245,7 @@ def test_generate_from_jams(atol=1e-5, rtol=1e-8):
             
         # Double trimming
         for _ in range(2):
-            with tempfile.TemporaryDirectory() as gen_events_path:
+            with backports.tempfile.TemporaryDirectory() as gen_events_path:
                 sc.generate(orig_wav_file.name, orig_jam_file.name,
                             disable_instantiation_warnings=True,
                             save_isolated_events=True)
@@ -264,7 +264,7 @@ def test_generate_from_jams(atol=1e-5, rtol=1e-8):
 
         # Triple trimming
         for _ in range(2):
-            with tempfile.TemporaryDirectory() as gen_events_path:
+            with backports.tempfile.TemporaryDirectory() as gen_events_path:
                 sc.generate(orig_wav_file.name, orig_jam_file.name,
                             disable_instantiation_warnings=True,
                             save_isolated_events=True)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -206,7 +206,7 @@ def test_generate_from_jams(atol=1e-5, rtol=1e-8):
             gen_wav, sr = soundfile.read(gen_wav_file.name)
             assert np.allclose(gen_wav, orig_wav, atol=atol, rtol=rtol)
 
-            # validate event audio is trimmed and sums to trimmed soundscape
+            # validate that the sum of event audio sums to trimmed soundscape
             gen_event_files = [
                 os.path.join(events_folder, x)
                 for x in sorted(os.listdir(events_folder))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -200,7 +200,8 @@ def test_generate_from_jams(atol=1e-5, rtol=1e-8):
                          time_stretch=('uniform', 0.8, 1.2))
 
 
-        def _validate_soundscape_and_event_audio(orig_wav_file, gen_wav_file, events_folder):
+        def _validate_soundscape_and_event_audio(orig_wav_file, gen_wav_file, 
+                                                 gen_events_path, orig_events_path):
             # validate audio
             orig_wav, sr = soundfile.read(orig_wav_file.name)
             gen_wav, sr = soundfile.read(gen_wav_file.name)
@@ -208,11 +209,14 @@ def test_generate_from_jams(atol=1e-5, rtol=1e-8):
 
             # validate that the sum of event audio sums to trimmed soundscape
             gen_event_files = [
-                os.path.join(events_folder, x)
-                for x in sorted(os.listdir(events_folder))
+                os.path.join(gen_events_path, x)
+                for x in sorted(os.listdir(gen_events_path))
             ]
             gen_audio = [soundfile.read(x)[0] for x in gen_event_files]
 
+            # Trim does not currently support trimming isolated events, but if/when
+            # we add that functionality, this test should be updated to test that
+            # as well, using the files in orig_events_path (currently unused).
             assert np.allclose(gen_wav, sum(gen_audio), atol=atol, rtol=rtol)
 
         # generate, then generate from the jams and compare audio files
@@ -229,10 +233,16 @@ def test_generate_from_jams(atol=1e-5, rtol=1e-8):
 
         # Now add in trimming!
         for _ in range(5):
-            with backports.tempfile.TemporaryDirectory() as gen_events_path:
+            with backports.tempfile.TemporaryDirectory() as isolated_events_path:
+                orig_events_path = os.path.join(isolated_events_path, 'original')
+                gen_events_path = os.path.join(isolated_events_path, 'generated')
+                os.makedirs(orig_events_path)
+                os.makedirs(gen_events_path)
+
                 sc.generate(orig_wav_file.name, orig_jam_file.name,
                             disable_instantiation_warnings=True,
-                            save_isolated_events=True)
+                            save_isolated_events=True, 
+                            isolated_events_path=orig_events_path)
                 scaper.trim(orig_wav_file.name, orig_jam_file.name,
                             orig_wav_file.name, orig_jam_file.name,
                             np.random.uniform(0, 5), np.random.uniform(5, 10))
@@ -241,14 +251,20 @@ def test_generate_from_jams(atol=1e-5, rtol=1e-8):
                                           isolated_events_path=gen_events_path)
 
                 _validate_soundscape_and_event_audio(orig_wav_file, gen_wav_file, 
-                    gen_events_path)
+                    gen_events_path, orig_events_path)
             
         # Double trimming
         for _ in range(2):
-            with backports.tempfile.TemporaryDirectory() as gen_events_path:
+            with backports.tempfile.TemporaryDirectory() as isolated_events_path:
+                orig_events_path = os.path.join(isolated_events_path, 'original')
+                gen_events_path = os.path.join(isolated_events_path, 'generated')
+                os.makedirs(orig_events_path)
+                os.makedirs(gen_events_path)
+
                 sc.generate(orig_wav_file.name, orig_jam_file.name,
                             disable_instantiation_warnings=True,
-                            save_isolated_events=True)
+                            save_isolated_events=True, 
+                            isolated_events_path=orig_events_path)
                 scaper.trim(orig_wav_file.name, orig_jam_file.name,
                             orig_wav_file.name, orig_jam_file.name,
                             np.random.uniform(0, 2), np.random.uniform(8, 10))
@@ -260,14 +276,20 @@ def test_generate_from_jams(atol=1e-5, rtol=1e-8):
                                           isolated_events_path=gen_events_path)
 
                 _validate_soundscape_and_event_audio(orig_wav_file, gen_wav_file, 
-                    gen_events_path)
+                    gen_events_path, orig_events_path)
 
         # Triple trimming
         for _ in range(2):
-            with backports.tempfile.TemporaryDirectory() as gen_events_path:
+            with backports.tempfile.TemporaryDirectory() as isolated_events_path:
+                orig_events_path = os.path.join(isolated_events_path, 'original')
+                gen_events_path = os.path.join(isolated_events_path, 'generated')
+                os.makedirs(orig_events_path)
+                os.makedirs(gen_events_path)
+
                 sc.generate(orig_wav_file.name, orig_jam_file.name,
                             disable_instantiation_warnings=True,
-                            save_isolated_events=True)
+                            save_isolated_events=True, 
+                            isolated_events_path=orig_events_path)
                 scaper.trim(orig_wav_file.name, orig_jam_file.name,
                             orig_wav_file.name, orig_jam_file.name,
                             np.random.uniform(0, 2), np.random.uniform(8, 10))
@@ -282,7 +304,7 @@ def test_generate_from_jams(atol=1e-5, rtol=1e-8):
                                           isolated_events_path=gen_events_path)
 
                 _validate_soundscape_and_event_audio(orig_wav_file, gen_wav_file, 
-                    gen_events_path)
+                    gen_events_path, orig_events_path)
 
         # Test with new FG and BG paths
         for _ in range(5):


### PR DESCRIPTION
This PR address #113. At the moment, I have updated the test case that looks at trimming to take into account when isolated sources are being saved. The test compares the trimmed audio of the original soundscape with the audio generated from the trimmed JAMS file. 

Then, the audio for each event generated from the trimmed JAMS file is summed to make sure it equals the trimmed soundscape.

One thing to note: I don't compare the audio generated from the trimmed JAMS file with the original event audio directly, as in the test loop each individual event audio is not fed into `scaper.trim`. Only the soundscape is trimmed. I think making sure it sums is enough to show that applying `trim` then `generate_from_jams` works.

This PR only has the test case so far, I'll update the code in `core.py` in the next commit.