### PR TITLE
Fixing some multichannel bugs when switching to in-memory ops.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,10 @@
 
 Changelog
 ---------
+v1.3.9
+~~~~~~
+- Fixed a bug where trim before generating soundscapes from a JAMS file with saving of isolated events resulted in incorrect soundscape audio.
+
 v1.3.8
 ~~~~~~
 - Fixed a bug where _sample_trunc_norm returned an array in Scipy 1.5.1, but returns a scalar in Scipy 1.4.0.

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -194,7 +194,7 @@ def generate_from_jams(jams_infile, audio_outfile, fg_path=None, bg_path=None,
                     tfm.trim(sliceop['slice_start'], sliceop['slice_end'])
                     tfm.build(audio_file, tmpfiles[-1].name)
                     # Copy result back to original file
-                    shutil.copyfile(tmpfiles[-1].name, audio_outfile)
+                    shutil.copyfile(tmpfiles[-1].name, audio_file)
 
     # Optionally save new jams file
     if jams_outfile is not None:

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -1892,7 +1892,6 @@ class Scaper(object):
                 if reverb is not None:
                     tfm.reverb(reverberance=reverb * 100)
                 # TODO: do we want to normalize the final output?
-
                 soundscape_audio = sum(event_audio_list)
                 soundscape_audio = tfm.build_array(
                     input_array=soundscape_audio,

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -1752,7 +1752,7 @@ class Scaper(object):
                         # Write event_audio_array to disk so we can compute LUFS using ffmpeg
                         soundfile.write(
                             tmpfiles_internal[-1].name, 
-                            event_audio.mean(axis=-1, keepdims=True), 
+                            event_audio,
                             self.sr
                         )
                         # NOW compute LUFS
@@ -1814,7 +1814,7 @@ class Scaper(object):
 
                         soundfile.write(
                             tmpfiles_internal[-1].name, 
-                            event_audio.mean(axis=-1, keepdims=True), 
+                            event_audio,
                             self.sr
                         )
                         # NOW compute LUFS
@@ -1869,7 +1869,7 @@ class Scaper(object):
                         # os.makedirs(..., exist_ok=True) but we test back to
                         # Python 2.7.
                         os.makedirs(event_folder)
-                    soundfile.write(event_audio_path, event_audio_list[-1].T, self.sr)
+                    soundfile.write(event_audio_path, event_audio_list[-1], self.sr)
                     isolated_events_audio_path.append(event_audio_path)
 
                     #TODO what do we do in this case? for now throw a warning

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -1869,7 +1869,7 @@ class Scaper(object):
                         # os.makedirs(..., exist_ok=True) but we test back to
                         # Python 2.7.
                         os.makedirs(event_folder)
-                    soundfile.write(event_audio_path, event_audio_list[-1], self.sr)
+                    soundfile.write(event_audio_path, event_audio_list[-1], self.sr, subtype='PCM_32')
                     isolated_events_audio_path.append(event_audio_path)
 
                     #TODO what do we do in this case? for now throw a warning
@@ -1898,7 +1898,7 @@ class Scaper(object):
                     sample_rate_in=self.sr,
                 )
                 soundscape_audio = soundscape_audio.reshape(-1, self.n_channels)
-                soundfile.write(audio_path, soundscape_audio, self.sr)
+                soundfile.write(audio_path, soundscape_audio, self.sr, subtype='PCM_32')
                         
         ann.sandbox.scaper.soundscape_audio_path = audio_path
         ann.sandbox.scaper.isolated_events_audio_path = isolated_events_audio_path

--- a/scaper/version.py
+++ b/scaper/version.py
@@ -3,4 +3,4 @@
 """Version info"""
 
 short_version = '1.3'
-version = '1.3.8'
+version = '1.3.9'

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         ],
     install_requires=[
         'sox==1.4.0b0',
-        'pyristent==0.15.4',
+        'pyrsistent==0.15.4',
         'jams>=0.3.2',
         'numpy>=1.13.3',
         'soundfile',

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,10 @@ setup(
         ],
     install_requires=[
         'sox==1.4.0b0',
+        'pyristent==0.14.0',
         'jams>=0.3.2',
         'numpy>=1.13.3',
-        'soundfile'
+        'soundfile',
     ],
     extras_require={
         'docs': [

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         ],
     install_requires=[
         'sox==1.4.0b0',
-        'pyristent==0.14.0',
+        'jsonschema==3.0.0',
         'jams>=0.3.2',
         'numpy>=1.13.3',
         'soundfile',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         ],
     install_requires=[
         'sox==1.4.0b0',
-        'jsonschema==3.0.0',
+        'pyristent==0.15.4',
         'jams>=0.3.2',
         'numpy>=1.13.3',
         'soundfile',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -217,7 +217,8 @@ def test_generate_from_jams(atol=1e-5, rtol=1e-8):
             # Trim does not currently support trimming isolated events, but if/when
             # we add that functionality, this test should be updated to test that
             # as well, using the files in orig_events_path (currently unused).
-            assert np.allclose(gen_wav, sum(gen_audio), atol=atol, rtol=rtol)
+            # atol = 1e-4, to match test_generate_isolated_events
+            assert np.allclose(gen_wav, sum(gen_audio), atol=1e-4, rtol=rtol)
 
         # generate, then generate from the jams and compare audio files
         # repeat 5 times

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -218,7 +218,7 @@ def test_generate_from_jams(atol=1e-5, rtol=1e-8):
             # we add that functionality, this test should be updated to test that
             # as well, using the files in orig_events_path (currently unused).
             # atol = 1e-4, to match test_generate_isolated_events
-            assert np.allclose(gen_wav, sum(gen_audio), atol=1e-4, rtol=rtol)
+            assert np.allclose(gen_wav, sum(gen_audio), atol=1e-8, rtol=rtol)
 
         # generate, then generate from the jams and compare audio files
         # repeat 5 times
@@ -1578,7 +1578,7 @@ def _test_generate_isolated_events(SR, isolated_events_path=None, atol=1e-4, rto
             isolated_audio.append(_isolated_sandbox_audio)
 
         # the sum of the isolated audio should sum to the soundscape
-        assert np.allclose(sum(isolated_audio), soundscape_audio, atol=1e-4, rtol=1e-8)
+        assert np.allclose(sum(isolated_audio), soundscape_audio, atol=1e-8, rtol=1e-8)
 
         jam = sc._instantiate(disable_instantiation_warnings=True)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1344,16 +1344,18 @@ def _test_generate_audio(SR, REG_WAV_PATH, REG_BGONLY_WAV_PATH, REG_REVERB_WAV_P
         # validate audio
         wav, sr = soundfile.read(wav_file.name, always_2d=True)
         regwav, sr = soundfile.read(REG_WAV_PATH, always_2d=True)
-        for ch in range(wav.shape[-1]):
-            assert np.allclose(wav[:, ch, None], regwav, atol=atol, rtol=rtol)
+        # TODO: Add multi-channel regression data.
+        if N_CHANNELS == 1:
+            assert np.allclose(wav, regwav, atol=atol, rtol=rtol)
 
         # with reverb
         sc._generate_audio(wav_file.name, jam.annotations[0], reverb=0.2)
         # validate audio
         wav, sr = soundfile.read(wav_file.name, always_2d=True)
         regwav, sr = soundfile.read(REG_REVERB_WAV_PATH, always_2d=True)
-        for ch in range(wav.shape[-1]):
-            assert np.allclose(wav[:, ch, None], regwav, atol=atol, rtol=rtol)
+        # TODO: Add multi-channel regression data.
+        if N_CHANNELS == 1:
+            assert np.allclose(wav, regwav, atol=atol, rtol=rtol)
 
         # Don't disable sox warnings (just to cover line)
         sc._generate_audio(wav_file.name, jam.annotations[0],
@@ -1361,8 +1363,9 @@ def _test_generate_audio(SR, REG_WAV_PATH, REG_BGONLY_WAV_PATH, REG_REVERB_WAV_P
         # validate audio
         wav, sr = soundfile.read(wav_file.name, always_2d=True)
         regwav, sr = soundfile.read(REG_WAV_PATH, always_2d=True)
-        for ch in range(wav.shape[-1]):
-            assert np.allclose(wav[:, ch, None], regwav, atol=atol, rtol=rtol)
+        # TODO: Add multi-channel regression data.
+        if N_CHANNELS == 1:
+            assert np.allclose(wav, regwav, atol=atol, rtol=rtol)
 
         # namespace must be scaper
         jam.annotations[0].namespace = 'tag_open'
@@ -1400,8 +1403,9 @@ def _test_generate_audio(SR, REG_WAV_PATH, REG_BGONLY_WAV_PATH, REG_REVERB_WAV_P
         # validate audio
         wav, sr = soundfile.read(wav_file.name, always_2d=True)
         regwav, sr = soundfile.read(REG_BGONLY_WAV_PATH, always_2d=True)
-        for ch in range(wav.shape[-1]):
-            assert np.allclose(wav[:, ch, None], regwav, atol=atol, rtol=rtol)
+        # TODO: Add multi-channel regression data.
+        if N_CHANNELS == 1:
+            assert np.allclose(wav, regwav, atol=atol, rtol=rtol)
 
 
 def create_scaper_scene_without_random_seed():


### PR DESCRIPTION
Discovered that there were issues with multichannel audio files when we switched to in-memory array-based processing of the audio. I tried to fix them here but ran into some issues:

- `ffmpeg` r128 stats reports different loudness if a file is multichannel vs if it's not! Strange!
- SoX appears to do slightly different things to an audio file if it's multi-channel vs if it's not, even when the two channels are exact duplicates of each other. I *thought* SoX processes channels independently, but that doesn't seem to be the case. I'll have to investigate further.

So the ways forward are maybe new regression data for multi-channel? Or to write a smoke test instead of a regression test to check that multi-channel doesn't crash (which it was before), but not to check if multi-channel == single channel.
