### PR TITLE
Return API for in-memory processing

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,12 @@
 
 Changelog
 ---------
+1.5.0
+~~~~~
+- Scaper now returns the generated audio and annotations directly in memory, allowing you to skip any/all file I/O!
+- Saving the audio and annotations to disk is still supported, but is now optional.
+- While this update modifies the API of several functions, it should still be backwards compatible.
+
 v1.4.0
 ~~~~~~
 - Operations on all files happen in-memory now, via new PySox features (build_array) and numpy operations for applying fades.

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -48,12 +48,22 @@ constants directly).
 '''
 
 
-def generate_from_jams(jams_infile, audio_outfile, fg_path=None, bg_path=None,
-                       jams_outfile=None, save_isolated_events=False, 
-                       isolated_events_path=None):
+def generate_from_jams(jams_infile,
+                       audio_outfile=None,
+                       fg_path=None,
+                       bg_path=None,
+                       jams_outfile=None,
+                       save_isolated_events=False,
+                       isolated_events_path=None,
+                       disable_sox_warnings=True,
+                       txt_path=None,
+                       txt_sep='\t'):
     '''
-    Generate a soundscape based on an existing scaper JAMS file and save to
-    disk.
+    Generate a soundscape based on an existing scaper JAMS file and return as
+    an audio file, a JAMS annotation, a simplified annotation list, and a
+    list containing the audio samples of each individual background and
+    foreground event. If output paths are provided, these objects will also
+    be saved to disk.
 
     Parameters
     ----------
@@ -91,6 +101,35 @@ def generate_from_jams(jams_infile, audio_outfile, fg_path=None, bg_path=None,
     isolated_events_path : str
         Path to folder for saving isolated events. If None, defaults to
         `<audio_outfile parent folder>/<audio_outfile name>_events`.
+    disable_sox_warnings : bool
+            When True (default), warnings from the pysox module are suppressed
+            unless their level is ``'CRITICAL'``. If you're experiencing issues related
+            to audio I/O setting this parameter to False may help with debugging.
+    txt_path: str or None
+            Path for saving a simplified annotation in a space separated format
+            [onset  offset  label]. Good for loading labels in e.g. Audacity. If
+            None, does not save txt annotation to disk.
+    txt_sep: str
+        The separator to use when saving a simplified annotation as a text
+        file (default is tab for compatibility with Audacity label files).
+        Only relevant if txt_path is not None.
+
+    Returns
+    -------
+    soundscape_audio : np.ndarray
+        The audio samples of the generated soundscape. Returns None if
+        no_audio=True.
+    soundscape_jam: jams.JAMS
+        The JAMS object containing the full soundscape annotation.
+    annotation_list : list
+        A simplified annotation in a space-separated format
+        [onset  offset  label].
+    event_audio_list: list
+        A list of np.ndarrays containing the audio samples of every
+        individual background and foreground sound event. Events are listed
+        in the same order in which they appear in the jams annotations data
+        list, and can be matched with:
+        `for obs, event_audio in zip(ann.data, event_audio_list): ...`.
 
     Raises
     ------
@@ -100,15 +139,15 @@ def generate_from_jams(jams_infile, audio_outfile, fg_path=None, bg_path=None,
         namespace.
 
     '''
-    jam = jams.load(jams_infile)
-    anns = jam.search(namespace='scaper')
+    soundscape_jam = jams.load(jams_infile)
+    anns = soundscape_jam.search(namespace='scaper')
 
     if len(anns) == 0:
         raise ScaperError(
             'JAMS file does not contain any annotation with namespace '
             'scaper.')
 
-    ann = jam.annotations.search(namespace='scaper')[0]
+    ann = soundscape_jam.annotations.search(namespace='scaper')[0]
 
     # Update paths
     if fg_path is None:
@@ -172,10 +211,11 @@ def generate_from_jams(jams_infile, audio_outfile, fg_path=None, bg_path=None,
 
     # Cast ann.sandbox.scaper to a Sandbox object
     ann.sandbox.scaper = jams.Sandbox(**ann.sandbox.scaper)
-    sc._generate_audio(audio_outfile, ann, reverb=reverb, 
-                       save_isolated_events=save_isolated_events, 
-                       isolated_events_path=isolated_events_path,
-                       disable_sox_warnings=True)
+    soundscape_audio, event_audio_list = \
+        sc._generate_audio(audio_outfile, ann, reverb=reverb,
+                           save_isolated_events=save_isolated_events,
+                           isolated_events_path=isolated_events_path,
+                           disable_sox_warnings=disable_sox_warnings)
 
     # If there are slice (trim) operations, need to perform them!
     # Need to add this logic for the isolated events too.
@@ -198,7 +238,22 @@ def generate_from_jams(jams_infile, audio_outfile, fg_path=None, bg_path=None,
 
     # Optionally save new jams file
     if jams_outfile is not None:
-        jam.save(jams_outfile)
+        soundscape_jam.save(jams_outfile)
+
+    # Create annotation list
+    annotation_list = []
+    for obs in ann.data:
+        if obs.value['role'] == 'foreground':
+            annotation_list.append(
+                [obs.time, obs.time + obs.duration, obs.value['label']])
+
+    if txt_path is not None:
+        with open(txt_path, 'w') as csv_file:
+            writer = csv.writer(csv_file, delimiter=txt_sep)
+            writer.writerows(annotation_list)
+
+    # Return
+    return soundscape_audio, soundscape_jam, annotation_list, event_audio_list
 
 
 def trim(audio_infile, jams_infile, audio_outfile, jams_outfile, start_time,
@@ -280,6 +335,7 @@ def trim(audio_infile, jams_infile, audio_outfile, jams_outfile, start_time,
                 tfm.build(audio_infile, tmpfiles[-1].name)
                 # Copy result back to original file
                 shutil.copyfile(tmpfiles[-1].name, audio_outfile)
+
 
 def _get_value_from_dist(dist_tuple, random_state):
     '''
@@ -1675,6 +1731,17 @@ class Scaper(object):
             When True (default), warnings from the pysox module are suppressed
             unless their level is ``'CRITICAL'``.
 
+        Returns
+        -------
+        soundscape_audio : np.ndarray
+            The audio samples of the generated soundscape
+        event_audio_list: list
+            A list of np.ndarrays containing the audio samples of every
+            individual background and foreground sound event. Events are listed
+            in the same order in which they appear in the jams annotations data
+            list, and can be matched with:
+            `for obs, event_audio in zip(ann.data, event_audio_list): ...`.
+
         Raises
         ------
         ScaperError
@@ -1696,10 +1763,11 @@ class Scaper(object):
         else:
             temp_logging_level = logging.getLogger().level
 
+        # List for storing all generated audio (one array for every event)
+        event_audio_list = []
+
         with _set_temp_logging_level(temp_logging_level):
 
-            # List for storing all generated audio (one array for every event)
-            event_audio_list = []
             isolated_events_audio_path = []
             duration_in_samples = int(self.duration * self.sr)
 
@@ -1886,7 +1954,7 @@ class Scaper(object):
             if len(event_audio_list) == 0:
                 warnings.warn(
                     "No events to synthesize (silent soundscape), no audio "
-                    "saved to disk.", ScaperWarning)
+                    "generated.", ScaperWarning)
             else:                        
                 tfm = sox.Transformer()
                 if reverb is not None:
@@ -1898,25 +1966,46 @@ class Scaper(object):
                     sample_rate_in=self.sr,
                 )
                 soundscape_audio = soundscape_audio.reshape(-1, self.n_channels)
-                soundfile.write(audio_path, soundscape_audio, self.sr, subtype='PCM_32')
-                        
+
+                # Save to disk if output path provided
+                if audio_path is not None:
+                    soundfile.write(audio_path, soundscape_audio, self.sr, subtype='PCM_32')
+
+        # Document output paths
         ann.sandbox.scaper.soundscape_audio_path = audio_path
         ann.sandbox.scaper.isolated_events_audio_path = isolated_events_audio_path
 
-    def generate(self, audio_path, jams_path, allow_repeated_label=True,
-                 allow_repeated_source=True,reverb=None, save_isolated_events=False, 
-                 isolated_events_path=None, disable_sox_warnings=True, no_audio=False, 
-                 txt_path=None, txt_sep='\t', disable_instantiation_warnings=False):
-        '''
-        Generate a soundscape based on the current specification and save to
-        disk as both an audio file and a JAMS file describing the soundscape.
+        # Return audio for in-memory processing
+        return soundscape_audio, event_audio_list
+
+    def generate(self,
+                 audio_path=None,
+                 jams_path=None,
+                 allow_repeated_label=True,
+                 allow_repeated_source=True,
+                 reverb=None,
+                 save_isolated_events=False,
+                 isolated_events_path=None,
+                 disable_sox_warnings=True,
+                 no_audio=False,
+                 txt_path=None,
+                 txt_sep='\t',
+                 disable_instantiation_warnings=False):
+        """
+        Generate a soundscape based on the current specification and return as
+        an audio file, a JAMS annotation, a simplified annotation list, and a
+        list containing the audio samples of each individual background and
+        foreground event. If output paths are provided, these objects will also
+        be saved to disk.
 
         Parameters
         ----------
         audio_path : str
-            Path for saving soundscape audio
+            Path for saving soundscape audio to disk. If None, does not save
+            audio to disk.
         jams_path : str
-            Path for saving soundscape jams
+            Path for saving soundscape jams annotation to disk. If None, does
+            not save JAMS to disk.
         allow_repeated_label : bool
             When True (default) the same label can be used more than once
             in a soundscape instantiation. When False every label can
@@ -1945,18 +2034,22 @@ class Scaper(object):
             or `background0_park.wav`.
         isolated_events_path : str
             Path to folder for saving isolated events. If None, defaults to
-            `<audio_path parent folder>/<audio_path name>_events`.
+            `<audio_path parent folder>/<audio_path name>_events`. Only relevant
+            if save_isolated_events=True.
         disable_sox_warnings : bool
             When True (default), warnings from the pysox module are suppressed
             unless their level is ``'CRITICAL'``. If you're experiencing issues related 
             to audio I/O setting this parameter to False may help with debugging.
         no_audio : bool
-            If true only generates a JAMS file and no audio is saved to disk.
+            If True this function will only generates a JAMS file but will not
+            generate any audio (neither in memory nor saved to disk). Useful for
+            efficiently generating a large number of soundscape JAMS for
+            later synthesis via `generate_from_jams()`.
         txt_path: str or None
-            If not None, in addition to the JAMS file output a simplified
-            annotation in a space separated format [onset  offset  label],
-            saved to the provided path (good for loading labels in audacity).
-        test_sep: str
+            Path for saving a simplified annotation in a space separated format
+            [onset  offset  label]. Good for loading labels in e.g. Audacity. If
+            None, does not save txt annotation to disk.
+        txt_sep: str
             The separator to use when saving a simplified annotation as a text
             file (default is tab for compatibility with Audacity label files).
             Only relevant if txt_path is not None.
@@ -1965,6 +2058,23 @@ class Scaper(object):
             instantiation (primarily about automatic duration adjustments) are
             disabled. Not recommended other than for testing purposes.
 
+        Returns
+        -------
+        soundscape_audio : np.ndarray
+            The audio samples of the generated soundscape. Returns None if
+            no_audio=True.
+        soundscape_jam: jams.JAMS
+            The JAMS object containing the full soundscape annotation.
+        annotation_list : list
+            A simplified annotation in a space-separated format
+            [onset  offset  label].
+        event_audio_list: list
+            A list of np.ndarrays containing the audio samples of every
+            individual background and foreground sound event. Events are listed
+            in the same order in which they appear in the jams annotations data
+            list, and can be matched with:
+            `for obs, event_audio in zip(ann.data, event_audio_list): ...`.
+
         Raises
         ------
         ScaperError
@@ -1972,11 +2082,13 @@ class Scaper(object):
 
         See Also
         --------
+        Scaper.generate_from_jams
+
         Scaper._instantiate
 
         Scaper._generate_audio
 
-        '''
+        """
         # Check parameter validity
         if reverb is not None:
             if not (0 <= reverb <= 1):
@@ -1985,31 +2097,38 @@ class Scaper(object):
                     'None.')
 
         # Create specific instance of a soundscape based on the spec
-        jam = self._instantiate(
+        soundscape_jam = self._instantiate(
             allow_repeated_label=allow_repeated_label,
             allow_repeated_source=allow_repeated_source,
             reverb=reverb,
             disable_instantiation_warnings=disable_instantiation_warnings)
-        ann = jam.annotations.search(namespace='scaper')[0]
+        ann = soundscape_jam.annotations.search(namespace='scaper')[0]
+
+        soundscape_audio, event_audio_list = None, None
 
         # Generate the audio and save to disk
         if not no_audio:
-            self._generate_audio(audio_path, ann, reverb=reverb, 
-                                 save_isolated_events=save_isolated_events,
-                                 isolated_events_path=isolated_events_path,
-                                 disable_sox_warnings=disable_sox_warnings)
+            soundscape_audio, event_audio_list = \
+                self._generate_audio(audio_path, ann, reverb=reverb,
+                                     save_isolated_events=save_isolated_events,
+                                     isolated_events_path=isolated_events_path,
+                                     disable_sox_warnings=disable_sox_warnings)
 
-        # Finally save JAMS to disk too
-        jam.save(jams_path)
+        # Save JAMS to disk too
+        if jams_path is not None:
+            soundscape_jam.save(jams_path)
 
-        # Optionally save to CSV as well
+        # Create annotation list
+        annotation_list = []
+        for obs in ann.data:
+            if obs.value['role'] == 'foreground':
+                annotation_list.append(
+                    [obs.time, obs.time + obs.duration, obs.value['label']])
+
         if txt_path is not None:
-            csv_data = []
-            for obs in ann.data:
-                if obs.value['role'] == 'foreground':
-                    csv_data.append(
-                        [obs.time, obs.time+obs.duration, obs.value['label']])
-
             with open(txt_path, 'w') as csv_file:
                 writer = csv.writer(csv_file, delimiter=txt_sep)
-                writer.writerows(csv_data)
+                writer.writerows(annotation_list)
+
+        # Return
+        return soundscape_audio, soundscape_jam, annotation_list, event_audio_list

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -107,8 +107,9 @@ def generate_from_jams(jams_infile,
             to audio I/O setting this parameter to False may help with debugging.
     txt_path: str or None
             Path for saving a simplified annotation in a space separated format
-            [onset  offset  label]. Good for loading labels in e.g. Audacity. If
-            None, does not save txt annotation to disk.
+            [onset  offset  label] where onset and offset are in seconds. Good
+            for loading labels in e.g. Audacity. If None, does not save txt
+            annotation to disk.
     txt_sep: str
         The separator to use when saving a simplified annotation as a text
         file (default is tab for compatibility with Audacity label files).
@@ -123,7 +124,7 @@ def generate_from_jams(jams_infile,
         The JAMS object containing the full soundscape annotation.
     annotation_list : list
         A simplified annotation in a space-separated format
-        [onset  offset  label].
+        [onset  offset  label] where onset and offset are in seconds.
     event_audio_list: list
         A list of np.ndarrays containing the audio samples of every
         individual background and foreground sound event. Events are listed
@@ -252,7 +253,6 @@ def generate_from_jams(jams_infile,
             writer = csv.writer(csv_file, delimiter=txt_sep)
             writer.writerows(annotation_list)
 
-    # Return
     return soundscape_audio, soundscape_jam, annotation_list, event_audio_list
 
 
@@ -2048,8 +2048,9 @@ class Scaper(object):
             later synthesis via `generate_from_jams()`.
         txt_path: str or None
             Path for saving a simplified annotation in a space separated format
-            [onset  offset  label]. Good for loading labels in e.g. Audacity. If
-            None, does not save txt annotation to disk.
+            [onset  offset  label] where onset and offset are in seconds. Good
+            for loading labels in e.g. Audacity. If None, does not save txt
+            annotation to disk.
         txt_sep: str
             The separator to use when saving a simplified annotation as a text
             file (default is tab for compatibility with Audacity label files).
@@ -2068,7 +2069,7 @@ class Scaper(object):
             The JAMS object containing the full soundscape annotation.
         annotation_list : list
             A simplified annotation in a space-separated format
-            [onset  offset  label].
+            [onset  offset  label] where onset and offset are in seconds.
         event_audio_list: list
             A list of np.ndarrays containing the audio samples of every
             individual background and foreground sound event. Events are listed

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -1764,6 +1764,7 @@ class Scaper(object):
             temp_logging_level = logging.getLogger().level
 
         # List for storing all generated audio (one array for every event)
+        soundscape_audio = None
         event_audio_list = []
 
         with _set_temp_logging_level(temp_logging_level):

--- a/scaper/version.py
+++ b/scaper/version.py
@@ -2,5 +2,5 @@
 # -*- coding: utf-8 -*-
 """Version info"""
 
-short_version = '1.4'
-version = '1.4.0'
+short_version = '1.5'
+version = '1.5.0'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -149,6 +149,32 @@ def _compare_scaper_jams(jam, regjam):
                 assert v[k] == regv[k]
 
 
+def _compare_txt_annotation(orig_txt_file, gen_txt_file):
+
+    # read in both files
+    txt_data = []
+    with open(orig_txt_file) as file:
+        reader = csv.reader(file, delimiter='\t')
+        for row in reader:
+            txt_data.append(row)
+    txt_data = np.asarray(txt_data)
+
+    gen_txt_data = []
+    with open(gen_txt_file) as file:
+        reader = csv.reader(file, delimiter='\t')
+        for row in reader:
+            gen_txt_data.append(row)
+    gen_txt_data = np.asarray(gen_txt_data)
+
+    # compare start and end times
+    assert np.allclose([float(x) for x in txt_data[:, 0]],
+                       [float(x) for x in gen_txt_data[:, 0]])
+    assert np.allclose([float(x) for x in txt_data[:, 1]],
+                       [float(x) for x in gen_txt_data[:, 1]])
+    # compare labels
+    assert (txt_data[:, 2] == gen_txt_data[:, 2]).all()
+
+
 def test_generate_from_jams(atol=1e-5, rtol=1e-8):
 
     # Test for invalid jams: no annotations
@@ -198,7 +224,6 @@ def test_generate_from_jams(atol=1e-5, rtol=1e-8):
                          snr=('uniform', 10, 20),
                          pitch_shift=('uniform', -1, 1),
                          time_stretch=('uniform', 0.8, 1.2))
-
 
         def _validate_soundscape_and_event_audio(orig_wav_file, gen_wav_file, 
                                                  gen_events_path, orig_events_path):
@@ -1675,28 +1700,7 @@ def _test_generate(SR, REG_WAV_PATH, REG_JAM_PATH, REG_TXT_PATH, atol=1e-4, rtol
         _compare_scaper_jams(jam, regjam)
 
         # validate txt
-        # read in both files
-        txt_data = []
-        with open(txt_file.name) as file:
-            reader = csv.reader(file, delimiter='\t')
-            for row in reader:
-                txt_data.append(row)
-        txt_data = np.asarray(txt_data)
-
-        regtxt_data = []
-        with open(REG_TXT_PATH) as file:
-            reader = csv.reader(file, delimiter='\t')
-            for row in reader:
-                regtxt_data.append(row)
-        regtxt_data = np.asarray(regtxt_data)
-
-        # compare start and end times
-        assert np.allclose([float(x) for x in txt_data[:, 0]],
-                           [float(x) for x in regtxt_data[:, 0]])
-        assert np.allclose([float(x) for x in txt_data[:, 1]],
-                           [float(x) for x in regtxt_data[:, 1]])
-        # compare labels
-        assert (txt_data[:, 2] == regtxt_data[:, 2]).all()
+        _compare_txt_annotation(txt_file.name, REG_TXT_PATH)
 
         # reverb value must be in (0, 1) range
         for reverb in [-1, 2]:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1783,8 +1783,7 @@ def _test_generate(SR, REG_WAV_PATH, REG_JAM_PATH, REG_TXT_PATH, atol=1e-4, rtol
 
 
 def test_generate_return_api():
-    # for sr in SAMPLE_RATES:
-    for sr in [44100]:
+    for sr in SAMPLE_RATES:
         REG_WAV_PATH, REG_JAM_PATH, REG_TXT_PATH = TEST_PATHS[sr]['REG']
         _test_generate_return_api(sr, REG_WAV_PATH, REG_JAM_PATH, REG_TXT_PATH)
 


### PR DESCRIPTION
This PR updates the API for `generate` and `generate_from_jams` so that they (also) return the generated audio (mix and events) + annotations in memory