### PR TITLE
Fixes bug with fade/in equal to zero and strengthens tests.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,8 +2,13 @@
 
 Changelog
 ---------
-1.5.0
-~~~~~
+v1.5.1
+~~~~~~
+- Fixes a bug with fade in and out lengths are set to 0.
+- This is the last version to support Python 2.7 and 3.4.
+
+v1.5.0
+~~~~~~
 - Scaper now returns the generated audio and annotations directly in memory, allowing you to skip any/all file I/O!
 - Saving the audio and annotations to disk is still supported, but is now optional.
 - While this update modifies the API of several functions, it should still be backwards compatible.

--- a/scaper/core.py
+++ b/scaper/core.py
@@ -1897,13 +1897,15 @@ class Scaper(object):
 
                         # Apply short fade in and out
                         # (avoid unnatural sound onsets/offsets)
-                        fade_in_samples =  int(self.fade_in_len * self.sr)
-                        fade_out_samples = int(self.fade_out_len * self.sr)
-                        fade_in_window = np.sin(np.linspace(0, np.pi / 2, fade_in_samples))[..., None]
-                        fade_out_window = np.sin(np.linspace(np.pi / 2, 0, fade_out_samples))[..., None]
+                        if self.fade_in_len > 0:
+                            fade_in_samples =  int(self.fade_in_len * self.sr)
+                            fade_in_window = np.sin(np.linspace(0, np.pi / 2, fade_in_samples))[..., None]
+                            event_audio[:fade_in_samples] *= fade_in_window
 
-                        event_audio[:fade_in_samples] *= fade_in_window
-                        event_audio[-fade_out_samples:] *= fade_out_window
+                        if self.fade_out_len > 0:
+                            fade_out_samples = int(self.fade_out_len * self.sr)
+                            fade_out_window = np.sin(np.linspace(np.pi / 2, 0, fade_out_samples))[..., None]
+                            event_audio[-fade_out_samples:] *= fade_out_window
 
                         # Pad with silence before/after event to match the
                         # soundscape duration

--- a/scaper/version.py
+++ b/scaper/version.py
@@ -3,4 +3,4 @@
 """Version info"""
 
 short_version = '1.5'
-version = '1.5.0'
+version = '1.5.1'


### PR DESCRIPTION
This PR addresses #124, fixing a bug with fades when set to 0.0. 

I also wrote a specific test also to make sure that fades are working when applied to an event at various fade lengths, up to half the soundscape duration.

Updated to 1.5.1, and also marked that as the last version to support Python 2.7 and 3.4.