### PR TITLE
Bump version to v1.6.5

### DIFF
--- a/scaper/version.py
+++ b/scaper/version.py
@@ -3,4 +3,4 @@
 """Version info"""
 
 short_version = '1.6'
-version = '1.6.5.rc0'
+version = '1.6.5'


### PR DESCRIPTION
Looks like our implementation of `choose_weighted` is [working well](https://github.com/justinsalamon/scaper/issues/143#issuecomment-779792320), so we should make a formal 1.6.5 release.

Closes #143 