### PR TITLE
Replace import imp with Python recommended importlib call

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,8 +95,20 @@ sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 # built documents.
 #
 # The short X.Y version.
-import imp
-scaper_version = imp.load_source('scaper.version', '../scaper/version.py')
+import importlib.util
+import importlib.machinery
+
+def load_source(modname, filename):
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
+
+scaper_version = load_source('scaper.version', '../scaper/version.py')
 version = scaper_version.short_version
 # The full version, including alpha/beta/rc tags.
 release = scaper_version.version

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,4 @@ addopts = --cov-report term-missing --cov scaper
 universal = 1
 
 [metadata]
-description-file = README.md
+description_file = README.md

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,22 @@
 from setuptools import setup
-import imp
+import importlib.util
+import importlib.machinery
+
+def load_source(modname, filename):
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
 
 
 with open('README.md') as file:
     long_description = file.read()
 
-version = imp.load_source('scaper.version', 'scaper/version.py')
+version = load_source('scaper.version', 'scaper/version.py')
 
 setup(
     name='scaper',


### PR DESCRIPTION
The update changing import imp to import importlib.util and import importlib.machinery and inclusion of a custom function are as recommended in the Python documentation: https://docs.python.org/3/whatsnew/3.12.html#imp . It may be preferable to include this function in a helpers.py or something like that rather than have two copies.

Another incidental change that was necessary due to another deprecation in syntax was the update of setup.cfg to have `description_file` in snake rather than kebab case.

Testing these changes the package installs successfully calling `python setup.py install` .